### PR TITLE
[release] temporary style patch for course about pages

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -2,3 +2,8 @@
 layout: raw
 permalink: /static/system-status/
 ---
+<style>
+  main.course .hero-banner img {
+    max-width: 100%;
+  }
+</style>


### PR DESCRIPTION
The course image on `/about` for courses was overflowing its container on some device sizes.  This should fix that.