### PR TITLE
add courses page placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ This repo serves as cms for some of the static content on our Open EdX site.  Co
 - `static-pages-sidebar-content.html` appears on the right hand side of faq/about pages on thegymnasium.com.
 - `privacy-policy.html` content which appears on the [privacy policy](https://thegymnasium.com/privacy) page on thegymnasium.com.
 - `final-exam-modal.html` content which appears when the exam score is calculated.
+
+
+### Courses Page
+- `courses/full-courses-description.html` is shown on the `/courses` page as the title and description used for the full courses subheader
+- `courses/gym-shorts-description.html` is shown on the `/courses` page as the title and description used for the Gym Shorts subheader

--- a/courses/full-courses-description.html
+++ b/courses/full-courses-description.html
@@ -1,0 +1,10 @@
+---
+layout: raw
+permalink: /static/courses/full-courses-description/
+---
+<h1 id="full">
+  Full Courses
+</h1>
+<p class="hero">
+  All our Full Courses are taught by experienced practitioners and focused on in-demand skills and technologies. Each includes 3 to 6 hours of video instruction, quizzes, assignments, a final exam, and certification when you pass!
+</p>

--- a/courses/gym-shorts-description.html
+++ b/courses/gym-shorts-description.html
@@ -1,0 +1,9 @@
+---
+layout: raw
+permalink: /static/courses/full-courses-description/
+---
+
+<h1 id="gymshorts">Gym Shorts</h1>
+<p class="hero">
+  Gym Shorts are short courses that all last under an hour. Like our Full Courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
+</p>

--- a/courses/gym-shorts-description.html
+++ b/courses/gym-shorts-description.html
@@ -1,6 +1,6 @@
 ---
 layout: raw
-permalink: /static/courses/full-courses-description/
+permalink: /static/courses/gym-shorts-description/
 ---
 
 <h1 id="gymshorts">Gym Shorts</h1>


### PR DESCRIPTION
This is a repeat of #39, but maybe just from the right branch:


# What this PR Does
Adds cms content for the `full courses` and `gym shorts` titles and descriptions which are seen on the `courses` page.  

I haven't tested this locally - jekyll is giving me a headache.  @andrewpmiller can you give this branch a quick look?  There should be 2 new URLs added:

- `/courses/full-course-description.html`
- `/courses/gym-shorts-description.html`
