### PR TITLE
[release] fixing home page hero for firefox

### DIFF
--- a/_includes/hero-dfg-2019.html
+++ b/_includes/hero-dfg-2019.html
@@ -11,7 +11,7 @@
             <p><strong>Back by popular demand</strong> — Aquent is awarding five $5,000 grants to creative pros like you who want to put their skills to good use.</p>
             <p>To enter the competition, submit a short video highlighting your favorite nonprofit and how they would use the grant if you win.</p>
             <div class="cta">
-              <a class="gym-button gym-button-secondary" href="https://designingforgood.com/?utm_source=gymnasium&utm_medium=web&utm_campaign=AQ_NA_design-grants&utm_content=11022018" target="_blank" rel="noopener noreferrer"><b>Learn More</b></a>
+              <a class="gym-button gym-button-secondary" href="https://designingforgood.com/?utm_source=gymnasium&utm_medium=web&utm_campaign=AQ_NA_design-grants&utm_content=11022018" target="_blank" rel="noopener"><b>Learn More</b></a>
             </div>
           </header>
         </div>


### PR DESCRIPTION
# What's in this release
- I removed `noreferrer` from the `Learn More` link on the home page hero for _Design for Good_, since there's a script on the page somewhere that breaks things for firefox when `noreferrer` is present on that link.  Not a perfect solution, obviously.  I'll have to do more digging to see what that script is really doing.