### PR TITLE
Feature/portable job module

### DIFF
--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,0 +1,35 @@
+
+{%- comment -%}
+
+
+To Do:
+Set defaults in case this include is called without the correct argumnents
+
+
+{%- endcomment -%}
+
+{%- capture url_args -%}
+?major_segment={{ include.major }}&minor_segment={{ include.minor }}
+{%- endcapture -%}
+
+{% case jekyll.environment %}
+
+{% when "development" %}
+{% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
+
+{% when "staging" %}
+{% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
+
+{% when "production" %}
+{% assign include_url = "https://gym-jobs-microservice-prod.herokuapp.com/table" %}
+
+{% endcase %}
+<!-- Environment: {{ jekyll.environment }} -->
+<!-- Args: {{ url_args }} -->
+<!-- Major Segment: {{ include.major }} -->
+<!-- Minor Segment: {{ include.minor }} -->
+<iframe src="{{ include_url }}{{ url_args }}"
+  id="jobs-microservice-frame"
+  class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"
+  style="width: 1px;min-width: 100%;border:0;"
+></iframe>

--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,33 +1,51 @@
 
 {%- comment -%}
+  Check to see that this include was called with a major segment
+  @@todo: Needs a sensible default
+{%- endcomment -%}
 
+{% if include.major != null %}
+  {% assign major_segment = include.major %}
+{% else %}
+  {% assign major_segment = '00000' %}
+{% endif %}
 
-To Do:
-Set defaults in case this include is called without the correct argumnents
+{%- comment -%}
+  Check to see that this include was called with a minor segment
+  @@todo: Needs a sensible default
+{%- endcomment -%}
 
+{% if include.minor != null %}
+  {% assign minor_segment = include.minor %}
+{% else %}
+  {% assign minor_segment = '00000' %}
+{% endif %}
 
+{%- comment -%}
+  Assemble the URL for the correct job module
 {%- endcomment -%}
 
 {%- capture url_args -%}
-?major_segment={{ include.major }}&minor_segment={{ include.minor }}
+?major_segment={{ major_segment }}&minor_segment={{ minor_segment }}
 {%- endcapture -%}
 
 {% case jekyll.environment %}
 
-{% when "development" %}
-{% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
+    {% when "development" %}
+    {% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
 
-{% when "staging" %}
-{% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
+    {% when "staging" %}
+    {% assign include_url = "https://gym-jobs-microservice-staging.herokuapp.com/table" %}
 
-{% when "production" %}
-{% assign include_url = "https://gym-jobs-microservice-prod.herokuapp.com/table" %}
+    {% when "production" %}
+    {% assign include_url = "https://gym-jobs-microservice-prod.herokuapp.com/table" %}
 
 {% endcase %}
+
 <!-- Environment: {{ jekyll.environment }} -->
 <!-- Args: {{ url_args }} -->
-<!-- Major Segment: {{ include.major }} -->
-<!-- Minor Segment: {{ include.minor }} -->
+<!-- Major Segment: {{ major_segment }} -->
+<!-- Minor Segment: {{ minor_segment }} -->
 <iframe src="{{ include_url }}{{ url_args }}"
   id="jobs-microservice-frame"
   class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"

--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,32 +1,24 @@
 
-{%- comment -%}
-  Check to see that this include was called with a major segment
-  @@todo: Needs a sensible default
-{%- endcomment -%}
-
 {% if include.major != null %}
-  {% assign major_segment = include.major %}
-{% else %}
-  {% assign major_segment = '00000' %}
+{%- capture majorSegment -%}
+  ?majorSegment={{ include.major }}
+{%- endcapture -%}
 {% endif %}
-
-{%- comment -%}
-  Check to see that this include was called with a minor segment
-  @@todo: Needs a sensible default
-{%- endcomment -%}
 
 {% if include.minor != null %}
-  {% assign minor_segment = include.minor %}
-{% else %}
-  {% assign minor_segment = '00000' %}
+  {% if include.major != null %}
+    {%- capture minorSegment -%}
+      &minorSegment={{ include.minor }}
+    {%- endcapture -%}
+    {% else %}
+    {%- capture minorSegment -%}
+      minorSegment={{ include.minor }}
+    {%- endcapture -%}
+  {% endif %}
 {% endif %}
 
-{%- comment -%}
-  Assemble the URL for the correct job module
-{%- endcomment -%}
-
 {%- capture url_args -%}
-?major_segment={{ major_segment }}&minor_segment={{ minor_segment }}
+{{ majorSegment }}{{ minorSegment }}
 {%- endcapture -%}
 
 {% case jekyll.environment %}
@@ -44,8 +36,8 @@
 
 <!-- Environment: {{ jekyll.environment }} -->
 <!-- Args: {{ url_args }} -->
-<!-- Major Segment: {{ major_segment }} -->
-<!-- Minor Segment: {{ minor_segment }} -->
+<!-- Major Segment: {{ majorSegment }} -->
+<!-- Minor Segment: {{ minorSegment }} -->
 <iframe src="{{ include_url }}{{ url_args }}"
   id="jobs-microservice-frame"
   class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"

--- a/tests/ux-landing.html
+++ b/tests/ux-landing.html
@@ -4,7 +4,7 @@ permalink: /tests/ux/
 ---
 
 
-{%- include modules/jobs.html major='0006' minor='0023' -%}
+{%- include modules/jobs.html major='6' minor='23' -%}
 
     <div style="margin-top: 80px">
         <!-- Does nothing but add space -->

--- a/tests/ux-landing.html
+++ b/tests/ux-landing.html
@@ -4,7 +4,7 @@ permalink: /tests/ux/
 ---
 
 
-{%- include modules/jobs.html major='03' minor='20' -%}
+{%- include modules/jobs.html major='0006' minor='0023' -%}
 
     <div style="margin-top: 80px">
         <!-- Does nothing but add space -->

--- a/tests/ux-landing.html
+++ b/tests/ux-landing.html
@@ -1,9 +1,11 @@
 ---
 layout: test-home-minimal
-permalink: /tests/ux
+permalink: /tests/ux/
 ---
 
 
+{%- include modules/jobs.html major='03' minor='20' -%}
+
     <div style="margin-top: 80px">
-    <!-- Does nothing but add space -->
+        <!-- Does nothing but add space -->
     </div>


### PR DESCRIPTION
This PR allows you to include the Job Module on any Jekyll-rendered page with an `include` directive that sets the job category to a specified major/minor segment. 

To see this in action, look at the test page at `/tests/ux/` and view the rendered source.

A jobs module to show UX Design jobs is called with this statement:
`{%- include modules/jobs.html major='0006' minor='0023' -%}`

The included module generates a number of comments that can be used for debugging:
```html
<!-- Environment: development -->
<!-- Args: ?major_segment=0006&minor_segment=0023 -->
<!-- Major Segment: 0006 -->
<!-- Minor Segment: 0023 -->
<iframe src="https://gym-jobs-microservice-staging.herokuapp.com/table?major_segment=0006&minor_segment=0023"
  id="jobs-microservice-frame"
  class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"
  style="width: 1px;min-width: 100%;border:0;"
></iframe>
```