### PR TITLE
use cwid for the segments

### DIFF
--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,25 +1,12 @@
 
-{% if include.major != null %}
-{%- capture majorSegment -%}
-  ?majorSegment={{ include.major }}
+{% if include.cwid != null %}
+{%- capture cwid -%}
+  {{ include.cwid }}
 {%- endcapture -%}
-{% endif %}
-
-{% if include.minor != null %}
-  {% if include.major != null %}
-    {%- capture minorSegment -%}
-      &minorSegment={{ include.minor }}
-    {%- endcapture -%}
-    {% else %}
-    {%- capture minorSegment -%}
-      minorSegment={{ include.minor }}
-    {%- endcapture -%}
-  {% endif %}
-{% endif %}
-
 {%- capture url_args -%}
-{{ majorSegment }}{{ minorSegment }}
+?cwid={{ cwid }}
 {%- endcapture -%}
+{% endif %}
 
 {% case jekyll.environment %}
 
@@ -35,11 +22,10 @@
 {% endcase %}
 
 <!-- Environment: {{ jekyll.environment }} -->
-<!-- Args: {{ url_args }} -->
-<!-- Major Segment: {{ majorSegment }} -->
-<!-- Minor Segment: {{ minorSegment }} -->
+<!-- CWID: {{ cwid}} -->
+<!-- url_args: {{ url_args }} -->
+
 <iframe src="{{ include_url }}{{ url_args }}"
   id="jobs-microservice-frame"
   class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"
-  style="width: 1px;min-width: 100%;border:0;"
-></iframe>
+  style="width: 1px;min-width: 100%;border:0;"></iframe>

--- a/hub-pages/ux-design.html
+++ b/hub-pages/ux-design.html
@@ -99,7 +99,7 @@ permalink: /static/ux-design/
     </header>
     <div class="list-hr">
 <!-- jobs mobule -->
-{%- include modules/jobs.html major='6' minor='23' -%}
+{%- include modules/jobs.html cwid='104,105,106,107' -%}
     </div>
     <div class="cta">
       <a class="gym-button" href="https://aquent.com/find-work/?k=&l=all&ux=on#content" title="Find Work — Aquent" target="_blank" rel="noopener"><b>View More Jobs</b></a>

--- a/tests/ux-landing.html
+++ b/tests/ux-landing.html
@@ -4,7 +4,7 @@ permalink: /tests/ux/
 ---
 
 
-{%- include modules/jobs.html major='6' minor='23' -%}
+{%- include modules/jobs.html cwid='104,105,106,107' -%}
 
     <div style="margin-top: 80px">
         <!-- Does nothing but add space -->


### PR DESCRIPTION
## What this is
This changes how we assemble the job module url and how we include it. 

## How it works
This include directive:
`{%- include modules/jobs.html cwid='104,105,106,107' -%}`

Should generate this result in the built page:
```html
<iframe src="https://gym-jobs-microservice-staging.herokuapp.com/table?cwid=104,105,106,107"
  id="jobs-microservice-frame"
  class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"
  style="width: 1px;min-width: 100%;border:0;"></iframe>
<div style="margin-top: 80px">
```

## How to test
https://staging.gymcms.xyz/tests/ux/