### PR TITLE
sort out image and css paths

### DIFF
--- a/_data/take5s/GYM-5001.yml
+++ b/_data/take5s/GYM-5001.yml
@@ -4,8 +4,6 @@ title: "Making a CSS Parallax Effect"
 date: 2019-10-28T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5001/
-art: https://jgagne.github.io/gym-take-5/details-page/img/video-posters/gym-5001-1920w.jpg
-og_art: https://jgagne.github.io/gym-take-5/details-page/img/video-posters/gym-5001-1920w.jpg
 poster_art: /img/take5/posters/gym-5001.jpg
 live: true
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5002.yml
+++ b/_data/take5s/GYM-5002.yml
@@ -4,8 +4,6 @@ title: "Creating a CSS Knockout Text Effect"
 date: 2019-10-29T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5002/
-art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-007.png
-og_art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-007.png
 poster_art: /img/take5/posters/gym-5002.jpg
 topic: "Web Design & Development"
 live: true

--- a/_data/take5s/GYM-5003.yml
+++ b/_data/take5s/GYM-5003.yml
@@ -4,8 +4,6 @@ title: "Adding a CSS Gradient Overlay to an Image"
 date: 2019-10-30T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5003/
-art: https://jgagne.github.io/gym-take-5/details-page/img/video-posters/gym-5003-1920w.jpg
-og_art: https://jgagne.github.io/gym-take-5/details-page/img/video-posters/gym-5003-1920w.jpg
 poster_art: /img/take5/posters/gym-5003.jpg
 topic: "Web Design & Development"
 permalink: /static/take5/:name

--- a/_data/take5s/GYM-5004.yml
+++ b/_data/take5s/GYM-5004.yml
@@ -6,7 +6,6 @@ course_type: take5
 url: /static/take5/GYM-5004/
 art:
 poster_art: /img/take5/posters/gym-5004.jpg
-og_art:
 topic: "Web Design & Development"
 live: true
 instructor: 'Jeremy Osborn'

--- a/_data/take5s/GYM-5004.yml
+++ b/_data/take5s/GYM-5004.yml
@@ -4,7 +4,6 @@ title: "Working with CSS Feature Queries"
 date: 2019-10-31T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5004/
-art:
 poster_art: /img/take5/posters/gym-5004.jpg
 topic: "Web Design & Development"
 live: true

--- a/_data/take5s/GYM-5004.yml
+++ b/_data/take5s/GYM-5004.yml
@@ -4,15 +4,14 @@ title: "Working with CSS Feature Queries"
 date: 2019-10-31T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5004/
-art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-004.png
+art:
 poster_art: /img/take5/posters/gym-5004.jpg
-og_art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-004.png
+og_art:
 topic: "Web Design & Development"
 live: true
 instructor: 'Jeremy Osborn'
 video_ID: VaHkQQ5xgac
 video_duration: "4:34"
-poster_art:
 featured: false
 short_description: "In this tutorial, Jeremy Osborn, Academic Director of Aquent Gymnasium, will teach you how to use new CSS features made for modern browsers without sacrificing accessibility."
 og_description: "In this tutorial, Jeremy Osborn will teach you how to use new CSS features made for modern browsers without sacrificing accessibility."

--- a/_data/take5s/GYM-5005.yml
+++ b/_data/take5s/GYM-5005.yml
@@ -4,8 +4,6 @@ title: "Creating a Duotone with CSS"
 date: 2019-11-01T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5005/
-art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-005.jpg
-og_art: https://jgagne.github.io/gym-take-5/catalog-page/img/video-posters/web-design/gym-take-5-005.jpg
 poster_art: /img/take5/posters/gym-5005.jpg
 topic: "Web Design & Development"
 live: true

--- a/_data/take5s/GYM-5006.yml
+++ b/_data/take5s/GYM-5006.yml
@@ -4,8 +4,6 @@ date: 2019-11-18T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5006/
 title: "Leading a Card Sorting Session"
-art:
-og_art:
 poster_art:
 topic: "User Experience"
 live: false

--- a/_data/take5s/GYM-5007.yml
+++ b/_data/take5s/GYM-5007.yml
@@ -4,8 +4,6 @@ date: 2019-11-19T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5007/
 title: "Conducting Customer Interviews"
-art:
-og_art:
 poster_art:
 topic: "User Experience"
 live: false

--- a/_data/take5s/GYM-5008.yml
+++ b/_data/take5s/GYM-5008.yml
@@ -4,8 +4,6 @@ date: 2019-11-20T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5008/
 title: "Writing Effective Survey Questions"
-art:
-og_art:
 poster_art:
 topic: "User Experience"
 live: false

--- a/_data/take5s/GYM-5009.yml
+++ b/_data/take5s/GYM-5009.yml
@@ -4,8 +4,6 @@ date: 2019-11-21T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5009/
 title: "Leading Your First Usability Test"
-art:
-og_art:
 poster_art:
 topic: "User Experience"
 live: false

--- a/_data/take5s/GYM-5010.yml
+++ b/_data/take5s/GYM-5010.yml
@@ -4,8 +4,6 @@ date: 2019-11-22T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5010/
 title: "Using the KJ Method"
-art:
-og_art:
 poster_art:
 topic: "User Experience"
 live: false

--- a/_data/take5s/GYM-5011.yml
+++ b/_data/take5s/GYM-5011.yml
@@ -4,8 +4,6 @@ title: "Using Smart Layout in Sketch"
 date: 2019-11-04T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5011/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5012.yml
+++ b/_data/take5s/GYM-5012.yml
@@ -4,8 +4,6 @@ title: "Prototyping in the Browser with CSS Grid Layout"
 date: 2019-11-05T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5012/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5013.yml
+++ b/_data/take5s/GYM-5013.yml
@@ -4,8 +4,6 @@ title: "Working With the Timeline in InVision Studio"
 date: 2019-11-06T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5013/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5014.yml
+++ b/_data/take5s/GYM-5014.yml
@@ -4,8 +4,6 @@ title: "Using Auto-Animate in Adobe XD"
 date: 2019-11-07T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5014/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5015.yml
+++ b/_data/take5s/GYM-5015.yml
@@ -4,8 +4,6 @@ title: "Creating Advanced Animations in Figma"
 date: 2019-11-08T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5015/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Jeremy Osborn"

--- a/_data/take5s/GYM-5016.yml
+++ b/_data/take5s/GYM-5016.yml
@@ -4,8 +4,6 @@ title: "Storytelling for Designers"
 date: 2019-11-11T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5017/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Lee Andrese"

--- a/_data/take5s/GYM-5017.yml
+++ b/_data/take5s/GYM-5017.yml
@@ -4,8 +4,6 @@ title: "How to Tell the Story of a Mid-Career Pivot"
 date: 2019-11-12T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5020/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Anne Ditmeyer"

--- a/_data/take5s/GYM-5018.yml
+++ b/_data/take5s/GYM-5018.yml
@@ -4,8 +4,6 @@ title: "Crafting Your Story"
 date: 2019-11-13T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5018/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Lee Andrese"

--- a/_data/take5s/GYM-5019.yml
+++ b/_data/take5s/GYM-5019.yml
@@ -4,8 +4,6 @@ title: "Self-Promotion Through Your Online Presence"
 date: 2019-11-14T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5019/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Anne Ditmeyer"

--- a/_data/take5s/GYM-5020.yml
+++ b/_data/take5s/GYM-5020.yml
@@ -4,8 +4,6 @@ title: "Knowing your Audience"
 date: 2019-11-15T00:00:00-04:00
 course_type: take5
 url: /static/take5/GYM-5016/
-art: 
-og_art:
 poster_art:
 live: false
 instructor: "Lee Andrese"

--- a/_includes/take5/recommended-content.html
+++ b/_includes/take5/recommended-content.html
@@ -66,7 +66,7 @@
             <section class="tutorial">
                 <a href="{{ tutorial1.title | slugify | prepend: domain_link  }}" title="Watch Video">
                   <div class="artwork" data-duration="{{ tutorial1.video_duration }}">
-                    <img alt="{{ tutorial1.title }}" src="{{ tutorial1.poster_art }}">
+                    <img alt="{{ tutorial1.title }}" src="{{ site.url }}{{ site.baseurl }}{{ tutorial1.poster_art }}">
                   </div>
                 </a>
               <header>
@@ -81,7 +81,7 @@
             <section class="tutorial">
                 <a href="{{ tutorial2.title | slugify | prepend: domain_link  }}" title="Watch Video">
                   <div class="artwork" data-duration="{{ tutorial2.video_duration }}">
-                    <img alt="{{ tutorial2.title }}" src="{{ tutorial2.poster_art }}">
+                    <img alt="{{ tutorial2.title }}" src="{{ site.url }}{{ site.baseurl }}{{ tutorial2.poster_art }}">
                   </div>
                 </a>
               <header>
@@ -96,7 +96,7 @@
             <section class="tutorial">
                 <a href="{{ tutorial3.title | slugify | prepend: domain_link  }}" title="Watch Video">
                   <div class="artwork" data-duration="{{ tutorial3.video_duration }}">
-                    <img alt="{{ tutorial3.title }}" src="{{ tutorial3.poster_art }}">
+                    <img alt="{{ tutorial3.title }}" src="{{ site.url }}{{ site.baseurl }}{{ tutorial3.poster_art }}">
                   </div>
                 </a>
               <header>
@@ -110,7 +110,7 @@
         </ul>
       </div>
       <div class="cta">
-        <a class="gym-button" href="https://thegymnasium.com/take5"><b>View Take 5 Catalog</b></a>
+        <a class="gym-button" href="{{ domain_link }}"><b>View Take 5 Catalog</b></a>
       </div>
     </section>
 
@@ -128,7 +128,7 @@
             <section class="course">
                 <a href="{{ course1.url }}">
                   <div class="artwork">
-                    <img alt="{{ course1.title }}" src="{{ course1.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ course1.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
+                    <img alt="{{ course1.title }}" src="{{ site.url }}{{ site.baseurl }}{{ course1.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ site.url }}{{ site.baseurl }}{{ course1.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
                   </div>
                 </a>
               <header>
@@ -140,7 +140,7 @@
             <section class="course">
                   <a href="{{ course2.url }}">
                   <div class="artwork">
-                      <img alt="{{ course2.title }}" src="{{ course2.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ course2.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
+                      <img alt="{{ course2.title }}" src="{{ site.url }}{{ site.baseurl }}{{ course2.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ site.url }}{{ site.baseurl }}{{ course2.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
                   </div>
                   </a>
               <header>
@@ -152,7 +152,7 @@
             <section class="course">
                   <a href="{{ course3.url }}">
                     <div class="artwork">
-                        <img alt="{{ course3.title }}" src="{{ course3.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ course3.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
+                        <img alt="{{ course3.title }}" src="{{ site.url }}{{ site.baseurl }}{{ course3.course_ID | downcase | prepend: '/img/course-artwork/png/' | append: '.png' }}" srcset="{{ site.url }}{{ site.baseurl }}{{ course3.course_ID | downcase | prepend: '/img/course-artwork/svg/' | append: '.svg' }}">
                     </div>
                   </a>
               <header>

--- a/_layouts/take5-meta.html
+++ b/_layouts/take5-meta.html
@@ -7,7 +7,7 @@
 <meta property="og:title" content="{{ course.title }}">
 <meta property="og:description" content="{{ course.og_description}}">
 <!-- 1.91:1 aspect ratio supported by LinkedIn/Twitter -->
-<meta property="og:image" content="{{ course.course_ID | downcase | append: '-og.png' | prepend: '/img/take5/og/' | absolute_url }}">
+<meta property="og:image" content="{{ site.url }}{{ site.baseurl }}{{ course.course_ID | downcase | append: '-og.png' | prepend: '/img/take5/og/' }}">
 <!-- Reuse Title or something more descriptive? -->
 <meta property="og:image:alt" content="{{ course.title | prepend: 'Video poster for tutorial titled '}}">
 <!-- /*/ Twitter Card / Summary with large image /*/ -->
@@ -18,7 +18,7 @@
 <meta name="twitter:title" content="{{ course.title }}">
 <meta name="twitter:description" content="{{ course.og_description }}">
 <!-- 1.91:1 aspect ratio supported by LinkedIn/Twitter -->
-<meta name="twitter:image" content="{{ course.course_ID | downcase | append: '-og.png' | prepend: '/img/take5/og/' | absolute_url }}">
+<meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}{{ course.course_ID | downcase | append: '-og.png' | prepend: '/img/take5/og/'}}">
 <!-- Reuse Title or something more descriptive? -->
 <meta name="twitter:image:alt" content="{{ course.title | prepend: 'Video poster for tutorial titled '}}">
 

--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -1,4 +1,21 @@
-<link rel="stylesheet" href="/css/take5.css" />
+{% case jekyll.environment %}
+
+{% when "development" %}
+{% assign domain_link = "https://courses.gymna.si/take5/" %}
+
+{% when "staging" %}
+{% assign domain_link = "https://courses.gymna.si/take5/" %}
+
+{% when "production" %}
+{% assign domain_link = "https://thegymnasium.com/take5/" %}
+
+{% endcase %}
+
+{%- if jekyll.environment == "development" -%}
+    {%- include take5/test-top.html -%}
+{%- endif -%}
+
+<link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
 {% include take5/detail-opener-js.html %} 
 {% assign course = site.data.take5s[page.course_ID] %}
@@ -143,6 +160,11 @@
       <h3><mark>No recommended content found!</mark></h3>
     {% endif %}
 </main>
+
+
+{%- if jekyll.environment == "development" -%}
+    {%- include take5/test-bottom.html -%}
+{%- endif -%}
 
 <!-- //
 Generated at: {{ site.time }}

--- a/take5/catalog-blitz.html
+++ b/take5/catalog-blitz.html
@@ -21,6 +21,10 @@ permalink: /static/take5/
 
 {% endcase %}
 
+{%- if jekyll.environment == "development" -%}
+    {%- include take5/test-top.html -%}
+{%- endif -%}
+
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
 {% include take5/detail-opener-js.html %}
@@ -100,9 +104,7 @@ permalink: /static/take5/
                 </header>
                     <div class="tutorial">
                         <div class="artwork" data-duration="{{ featured_video_duration }}">
-                        <a href="{{ featured_url }}" title="Watch Video">
-                        <img alt="{{ featured_description }}" src="{{ featured_poster_art }}">
-                        </a>
+                        <a href="{{ featured_url }}" title="Watch Video"><img alt="{{ featured_description }}" src="{{ site.url }}{{ site.baseurl }}{{ featured_poster_art }}"></a>
                     </div>
                     <header>
                         <h2 class="all-caps subhead-topic">{{ featured_topic }}</h2>
@@ -167,8 +169,7 @@ permalink: /static/take5/
         <article class="tutorial">
             <div class="artwork" data-duration="{{ recent_take5.video_duration }}">
                 <a href="{{ recent_take5.title | slugify | prepend: domain_link }}" title="Watch Video">
-                <img alt="{{ recent_take5.title }}" src="{{ recent_take5.poster_art }}">
-                </a>
+                <img alt="{{ recent_take5.title }}" src="{{ site.url }}{{ site.baseurl }}{{ recent_take5.poster_art }}"></a>
             </div>
             <header>
                 <h4 class="all-caps subhead-topic">{{ recent_take5.topic }}</h4>
@@ -190,3 +191,7 @@ permalink: /static/take5/
 
 
 </main>
+
+{%- if jekyll.environment == "development" -%}
+    {%- include take5/test-top.html -%}
+{%- endif -%}


### PR DESCRIPTION
## What this PR does:
- Addresses issue #142 with fully qualified urls for images and css (i.e. no more relative-to-gymcms image paths!)
- Fixes image/style issues in catalog, detail, recommended content, and meta headers!
- "View Take 5 Catalog" button points to staging or production sites (environmentally aware)
- Loads the page top/bottom partials for local debugging _only_ if `jekyll_environment == development` — i.e. not be included in the pages that are built for staging/production
- removes og_art references in the data files (paths to `og_art` are now derived from `course_id`)
