### PR TITLE
add course catalog module for take 5

### DIFF
--- a/_includes/take5/course-catalog-description.html
+++ b/_includes/take5/course-catalog-description.html
@@ -1,0 +1,4 @@
+<p>
+Take 5 video tutorials cover practical skills in just 5 minutes. Topics range from web design to career development. 
+Some hands-on videos involve working with prototyping tools such as Sketch, Figma, and Adobe XD — along with HTML & CSS.
+</p>

--- a/css/take5-course-catalog.css
+++ b/css/take5-course-catalog.css
@@ -1,0 +1,18 @@
+#take5-list figure > a {
+    display: block;
+    height: 0;
+    background-color: #d2d2d2;
+    padding-bottom: 44.444444444444444%;
+    border: 1px solid #ddd;
+    border-bottom: 0;
+    overflow: hidden;
+  }
+  
+  #take5-list .img-responsive {
+    display: inline-block;
+    margin-top: -5%;
+  }
+  
+  #take5-list .course-description h2 {
+    margin-top: 0;
+  }

--- a/take5/course-catalog-module.html
+++ b/take5/course-catalog-module.html
@@ -2,3 +2,92 @@
 layout: raw
 permalink: /static/take5-catalog-module/
 ---
+{% case jekyll.environment %}
+
+{% when "development" %}
+{% assign domain_link = "https://courses.gymna.si/take5/" %}
+
+{% when "staging" %}
+{% assign domain_link = "https://courses.gymna.si/take5/" %}
+
+{% when "production" %}
+{% assign domain_link = "https://thegymnasium.com/take5/" %}
+
+{% endcase %}
+
+<link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5-course-catalog.css">
+
+{%- assign pubdates = ""  | split: ", " -%}
+{%- assign publish_order = ""  | split: ", " -%}
+
+{%- assign recent = ""  | split: ", " -%}
+{%- assign upcoming = ""  | split: ", " -%}
+
+{% assign catalog = site.data.take5s | sort %}
+
+{% for take5_hash in catalog %}
+    {% assign item = take5_hash[1] %}
+    {%- assign pubdates = pubdates | push: item.date -%}
+{% endfor %}
+
+{%- assign pubdates_sorted = pubdates | sort -%}
+
+{%- for pubdate in pubdates_sorted -%}
+    
+    {% for take5_hash in catalog %}
+        {% assign item = take5_hash[1] %}
+        {%- if item.date == pubdate -%}
+            {%- assign publish_order = publish_order | push: item.course_ID -%}
+        {%- endif -%}
+    {% endfor %}
+
+{%- endfor -%}
+
+{%- assign publish_order = publish_order | uniq | join: ', '|split: ', '  -%}
+
+{%- for item in publish_order -%}
+
+{%- if site.data.take5s[item].live == true -%}
+
+    {%- assign recent = recent | push: site.data.take5s[item].course_ID -%}
+    {%- endif -%}
+{%- endfor -%}
+
+ {%- assign recent = recent | reverse -%}
+
+<h1 id="take5">Take 5</h1>
+{%- include take5/course-catalog-description.html -%}
+
+
+
+<ul class="listing-courses" id="take5-list">
+
+{%- for item in recent -%}
+{%- assign recent_take5 = site.data.take5s[item] -%}
+
+<li class="course-item" data-course-id="{{ recent_take5.course_ID | remove: 'GYM-' }}">
+  <article class="row">
+    <figure class="col-md-4">
+      <a href="{{ recent_take5.title | slugify | prepend: domain_link }}">
+        <img class="img-responsive" src="{{ site.url }}{{ site.baseurl }}{{ recent_take5.poster_art }}" alt="{{ recent_take5.course_ID | remove: 'gym-' }} {{ recent_take5.title }} Cover Image">
+      </a>
+      <figcaption>
+        <a href="{{ recent_take5.title | slugify | prepend: domain_link }}" class="gym-button"><b>Watch Now</b></a>
+      </figcaption>
+    </figure>
+    <div class="col-md-8 course-description">
+      <header>
+        <h2>{{ recent_take5.topic }}</h2>
+        <h1>{{ recent_take5.title }}</h1>
+      </header>
+      <p>
+        {{ recent_take5.short_description }}
+      </p>
+    </div>
+  </article>
+</li>
+
+
+{%- endfor -%}
+
+</ul>


### PR DESCRIPTION
## What this PR does:
- Adds a module to list Take 5 tutorials in the Gymnasium course catalog
- Adds a simple include for the description text for this module (for simplified copy edits)
- Closes #146

## Notes:
- Items are listed by publish date — beginning with the most most recent
- **Currently there is no limit to the length of this list**