### PR TITLE
Fixing detail layout for take5 detail pages, I think

### DIFF
--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -35,113 +35,112 @@
     </div>
 
     <!-- The duration of this video is {{course.video_duration}} -->
+    <div class="container">
+      <div class="take5--info" id="tutorial-info">
+        <!-- Tutorial container-->
+        <header>
+          <h1 class="title all-caps">{{ course.title }}</h1>
 
-    <div class="take5--info" id="tutorial-info">
-      <!-- Tutorial container-->
-      <header>
-        <h1 class="title all-caps">{{ course.title }}</h1>
+          {% if course.instructor !=null %}
+          <p class="instructor">With {{ course.instructor }}</p>
+          {% endif %}
+        </header>
+        <p class="description">{{ course.short_description }}</p>
 
-        {% if course.instructor !=null %}
-        <p class="instructor">With {{ course.instructor }}</p>
-        {% endif %}
-      </header>
-      <p class="description">{{ course.short_description }}</p>
+        {%- comment -%} 
+        // 
+        // RELATED CONTENT 
+        // 
+        (Code and other links) 
+        // 
+        {%- endcomment -%}
+        <div>
+          <!-- Resources -->
 
-      {%- comment -%} 
-      // 
-      // RELATED CONTENT 
-      // 
-      (Code and other links) 
-      // 
-      {%- endcomment -%}
-      <div>
-        <!-- Resources -->
-
-        {% if course.project_files == null and course.related_content == null %}
-        <!-- No resources found! -->
-        {% else %}
-        <details open class="take5--resources" id="tutorial-resources">
-          <summary aria-expanded="true/false" tabindex="0" role="button"
-            ><b role="heading">Resources</b></summary
-          >
-          <div class="take5--resources-list">
-            <!-- Project Files -->
-            {% endif %} 
-            {% if course.project_files !=null %}
-            <header>
-              <h3>Project Files</h3>
-              {% if course.project_file_source !=null %}
-              <p>on {{ course.project_file_source }}</p>
+          {% if course.project_files == null and course.related_content == null %}
+          <!-- No resources found! -->
+          {% else %}
+          <details open class="take5--resources" id="tutorial-resources">
+            <summary aria-expanded="true/false" tabindex="0" role="button">
+              <b role="heading">Resources</b>
+            </summary>
+            <div class="take5--resources-list">
+              <!-- Project Files -->
+              {% endif %} 
+              {% if course.project_files !=null %}
+              <header>
+                <h3>Project Files</h3>
+                {% if course.project_file_source !=null %}
+                <p>on {{ course.project_file_source }}</p>
+                {% endif %}
+              </header>
+              <ul>
+                {% for item in course.project_files %} 
+                {%- if item.url contains ".zip" -%}
+                <li>
+                  <a href="{{ item.url }}" rel="noopener">{{ item.label }}</a>
+                </li>
+                {%- else -%}
+                <li>
+                  <a href="{{ item.url }}" target="_blank" rel="noopener">{{item.label}}</a>
+                </li>
+                {% endif %} {% endfor %}
+              </ul>
               {% endif %}
-            </header>
-            <ul>
-              {% for item in course.project_files %} 
-              {%- if item.url contains ".zip" -%}
-              <li>
-                <a href="{{ item.url }}" rel="noopener">{{ item.label }}</a>
-              </li>
-              {%- else -%}
-              <li>
-                <a href="{{ item.url }}" target="_blank" rel="noopener">{{
-                  item.label
-                }}</a>
-              </li>
-              {% endif %} {% endfor %}
-            </ul>
-            {% endif %}
-          </div>
-          <!-- /Project Files -->
-
-          <div class="take5--resources-list">
-            <!-- Related Content -->
-            {% if course.related_content !=null %} 
-            {% if course.project_files !=null %}
-            <h3>Related Content</h3>
-            {% endif %}
-            <ul>
-              {% for item in course.related_content %} 
-              {%- if item.url contains "thegymnasium.com" -%}
-              <li>
-                <a href="{{ item.url }}">{{ item.label }}</a>
-              </li>
-              {%- else -%}
-              <li>
-                <a href="{{ item.url }}" target="_blank" rel="noopener">{{
-                  item.label
-                }}</a>
-              </li>
-              {%- endif -%} {% endfor %}
-            </ul>
-            {% endif %}
-          </div>
-          <!-- Related Content -->
-        </details>
-      </div>
-      <!-- /Resources -->
-
-      <div>
-        <!-- Transcript -->
-        <details class="take5--resources" id="tutorial-transcript">
-          <summary aria-expanded="true/false" tabindex="0" role="button"
-            ><b>Transcript</b></summary
-          >
-          <article
-            class="take5--transcript"
-            id="{{ course.course_ID }}-transcript"
-          >
-            <header class="visuallyhidden">
-              <h1>{{ course.title }}</h1>
-              <p>with {{ course.instructor }}</p>
-            </header>
-            {{ content }}
-            <!-- Transcript word count: {{ page.content | number_of_words }} -->
-            <div class="to-top-link">
-              <a href="#tutorial-info"><b>Back to top</b></a>
             </div>
-          </article>
-        </details>
+            <!-- /Project Files -->
+
+            <div class="take5--resources-list">
+              <!-- Related Content -->
+              {% if course.related_content !=null %} 
+              {% if course.project_files !=null %}
+              <h3>Related Content</h3>
+              {% endif %}
+              <ul>
+                {% for item in course.related_content %} 
+                {%- if item.url contains "thegymnasium.com" -%}
+                <li>
+                  <a href="{{ item.url }}">{{ item.label }}</a>
+                </li>
+                {%- else -%}
+                <li>
+                  <a href="{{ item.url }}" target="_blank" rel="noopener">{{
+                    item.label
+                  }}</a>
+                </li>
+                {%- endif -%} {% endfor %}
+              </ul>
+              {% endif %}
+            </div>
+            <!-- Related Content -->
+          </details>
+        </div>
+        <!-- /Resources -->
+
+        <div>
+          <!-- Transcript -->
+          <details class="take5--resources" id="tutorial-transcript">
+            <summary aria-expanded="true/false" tabindex="0" role="button">
+              <b>Transcript</b>
+            </summary>
+            <article
+              class="take5--transcript"
+              id="{{ course.course_ID }}-transcript"
+            >
+              <header class="visuallyhidden">
+                <h1>{{ course.title }}</h1>
+                <p>with {{ course.instructor }}</p>
+              </header>
+              {{ content }}
+              <!-- Transcript word count: {{ page.content | number_of_words }} -->
+              <div class="to-top-link">
+                <a href="#tutorial-info"><b>Back to top</b></a>
+              </div>
+            </article>
+          </details>
+        </div>
+        <!-- /Transcript -->
       </div>
-      <!-- /Transcript -->
     </div>
     <!-- /Tutorial container -->
   </article>


### PR DESCRIPTION
# What this PR does
On the take5 detail page:
- removes some bad auto formatting done by a bad prettier config
- adds a `container` div around the content of the page