### PR TITLE
Update grid layout auto-sizing strategy

### DIFF
--- a/css/take5.css
+++ b/css/take5.css
@@ -661,11 +661,11 @@ details.take5--transcript {
   @media (min-width: 36em) {
 
     .cols-max-2 ul {
-      grid-template-columns: repeat(auto-fit, minmax(24em, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(24em, 1fr));
     }
 
     .cols-max-3 ul {
-      grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(20em, 1fr));
     }
 
   }


### PR DESCRIPTION
Use auto-fill instead of auto-fit.

This PR should fix the following auto-sizing issue (documentation courtesy of @andrewpmiller):

![grid-layout-auto-sizing-issue](https://user-images.githubusercontent.com/5142085/67589415-66619580-f726-11e9-98f6-39ada2942cde.png)




