### PR TITLE
Toggle Project/Lesson subheading

### DIFF
--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -71,9 +71,9 @@
           <!-- No resources found! -->
           {% else %}
           <details open class="take5--resources" id="tutorial-resources">
-            <summary aria-expanded="true/false" tabindex="0" role="button"
-              ><b role="heading">Resources</b></summary
-            >
+            <summary aria-expanded="true/false" tabindex="0" role="button">
+              <b role="heading">Resources</b>
+            </summary>
             <div class="take5--resources-list">
               <!-- Project Files -->
               {% endif %}

--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -79,7 +79,12 @@
               {% endif %}
               {% if course.project_files !=null %}
               <header>
+                {% if course.project_file_source == "GitHub" %}
+                <h3>Lesson Files</h3>
+                {% endif %}
+                {% if course.project_file_source == "CodePen" %}
                 <h3>Project Files</h3>
+                {% endif %}
                 {% if course.project_file_source !=null %}
                 <p>on {{ course.project_file_source }}</p>
                 {% endif %}


### PR DESCRIPTION
This PR should:

- Add pseudo logic to toggle Lesson/Project subheading based on “GitHub” or “CodePen” file source
- Tidy up related markup in Resources section

**GitHub** source:

![lesson-files](https://user-images.githubusercontent.com/5142085/68052579-4ef35100-fcc0-11e9-8355-bc4827706265.png)

**CodePen** source:

![project-files](https://user-images.githubusercontent.com/5142085/68052576-4e5aba80-fcc0-11e9-9e7d-61e15f911c6a.png)