### PR TITLE
Update Twitter summary card size

### DIFF
--- a/take5/meta/catalog-meta.html
+++ b/take5/meta/catalog-meta.html
@@ -4,7 +4,7 @@ permalink: /static/take5/meta/catalog-meta/
 ---
 <meta name="description" content="Learn a practical skill in 5 minutes for free.">
 <meta name="author" content="Aquent Gymnasium">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@AquentGymnasium">
 <meta name="twitter:url" property="og:url" content="https://thegymnasium.com/take5/">
 <meta name="twitter:title" property="og:title" content="Take 5">


### PR DESCRIPTION
This PR should provide the Take 5 catalog page with a larger “summary_large_image” card size instead of a smaller “summary” that currently displays (as shown below):

`#digitaltransformationpending`
![take5-twitter-summary-card](https://user-images.githubusercontent.com/5142085/68120920-76bb0280-fed4-11e9-9ff6-f492542f0537.png)
