### PR TITLE
Update Take 5 hero style

### DIFF
--- a/css/hero-gym-take5.css
+++ b/css/hero-gym-take5.css
@@ -50,12 +50,16 @@
     background-position: left center;
   }
 
+  .hero-content-copy {
+    padding-left: 1.4em;
+  }
+
 }
 
 /* content / copy */
 
 .hero-content-copy {
-  padding-left: 1.4em;
+  padding-left: .4em;
   margin-top: 6%;
   margin-bottom: 4%;
 }


### PR DESCRIPTION
This PR should reduce the left hand padding in the Take 5 hero for better left alignment (to the GYM brand) and add more horizontal space (for content) on smaller screens.