### PR TITLE
Update Take 5 hero

### DIFF
--- a/_includes/take5/hero-take5-blitz.html
+++ b/_includes/take5/hero-take5-blitz.html
@@ -44,7 +44,7 @@
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/hero-gym-take5.css">
   <div class="{{ 'hero-promo' }} {{ hero_style }}" id="hero-{{ hero_ID }}">
   <div class="container">
-    <div class="hero-content-art" style="background-color: #333; background-image: url('{{ site.url }}{{ site.baseurl }}/img/take5/posters/{{ hero_ID }}-hero.jpg'); background-size: cover; border-right: 2px solid #ccc;"></div>
+    <div class="hero-content-art" style="background-image: url('{{ site.url }}{{ site.baseurl }}/img/take5/posters/{{ hero_ID }}-hero.jpg'); border-image-source: url('{{ site.url }}{{ site.baseurl }}/img/take5/posters/{{ hero_ID }}-hero.jpg');"></div>
     <div class="hero-content-copy">
       <header>
         <h3 class="subhead-topic">{{ hero_topic }}</h3>

--- a/css/hero-gym-take5.css
+++ b/css/hero-gym-take5.css
@@ -39,15 +39,31 @@
     min-height: 25.125em;
   }
 
-  .hero-content-art {
+  .hero-promo .hero-content-art {
     display: block;
     position: absolute;
     top: 0;
     left: -100%;
     width: 100%;
     height: 100%;
+    background-color: #333;
     background-repeat: no-repeat;
     background-position: left center;
+    background-size: cover;
+    border-right: 2px solid #ccc;
+    border-image-slice: 1;
+    border-image-width: 0 0 0 999em;
+    border-image-repeat: stretch;
+    border-image-outset: 0 0 0 999em;
+  }
+
+  .hero-promo .hero-content-art::after {
+    display: block;
+    position: relative;
+    left: 2px;
+    content: "";
+    height: 100%;
+    border-right: 2px solid #ccc;
   }
 
   .hero-content-copy {


### PR DESCRIPTION
This PR should add better display of Take 5 hero imagery, by attempting to add a continuous background-image.

Example 1:

![hero-fill-example-1](https://user-images.githubusercontent.com/5142085/68520486-204c1c00-0266-11ea-9f5d-73b13557f5c8.png)

Example 2:

![hero-fill-example-2](https://user-images.githubusercontent.com/5142085/68520487-2215df80-0266-11ea-93c5-b549ac3cee56.png)


