### PR TITLE
remove trailing slash in catalog url

### DIFF
--- a/take5/meta/catalog-meta.html
+++ b/take5/meta/catalog-meta.html
@@ -6,7 +6,7 @@ permalink: /static/take5/meta/catalog-meta/
 <meta name="author" content="Aquent Gymnasium">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@AquentGymnasium">
-<meta name="twitter:url" property="og:url" content="https://thegymnasium.com/take5/">
+<meta name="twitter:url" property="og:url" content="https://thegymnasium.com/take5">
 <meta name="twitter:title" property="og:title" content="Take 5">
 <meta name="twitter:image" property="og:image" content="{{ site.url }}{{ site.baseurl }}/img/take5/og/gym-take5-og.png">
 <meta name="twitter:description" property="og:description" content="Learn a practical skill in 5 minutes for free.">


### PR DESCRIPTION
## What the PR does:

- Fixes an egregious bug where there was a trailing slash in the OG link for the Take 5 catalog page!
- addresses #152
