### PR TITLE
trims trailing slash from catalog url (#152)

### DIFF
--- a/_includes/take5/recommended-content.html
+++ b/_includes/take5/recommended-content.html
@@ -118,7 +118,7 @@
         </ul>
       </div>
       <div class="cta">
-        <a class="gym-button" href="{{ domain_link }}"><b>View Take 5 Catalog</b></a>
+        <a class="gym-button" href="{{ domain_link | replace: '/take5/', '/take5' }}"><b>View Take 5 Catalog</b></a>
       </div>
     </section>
 


### PR DESCRIPTION
## What this PR does:

- Removes the trailing slash from the link to the Take 5 catalog that appears in the recommended courses module on the Take 5 tutorial detail page.

## How to test this (completely):

- Build this branch locally
- Edit the include directive on line 180 of `_layouts/take5-raw.html` so that `rec-take5=true`
(i.e.`{%- include /take5/recommended-content.html rec-take5=false rec-courses=true -%}`)
- View a detail page (http://0.0.0.0:4000/static/take5/gym-5003)
- Verify that the "View Take 5 Catalog" button links to the catalog page correctly (i.e. no trailing slash)

