### PR TITLE
Update Full Courses description

### DIFF
--- a/courses/full-courses-description.html
+++ b/courses/full-courses-description.html
@@ -6,5 +6,5 @@ permalink: /static/courses/full-courses-description/
   Full Courses
 </h1>
 <p class="hero">
-  All our Full Courses are taught by industry experts and focus on current skills and technologies. Each includes 3 to 6 hours of video instruction, optional quizzes and assignments, a final exam, and certificate (if and) when you pass.
+  Full Courses are taught by industry experts and focus on current skills and technologies. Each includes 3 to 6 hours of video instruction, optional quizzes and assignments, a final exam, and certificate (if and) when you pass.
 </p>


### PR DESCRIPTION
This PR removes the “All our” lead-in, in the Full Courses description.