### PR TITLE
Update script load

### DIFF
--- a/_includes/take5/detail-opener-js.html
+++ b/_includes/take5/detail-opener-js.html
@@ -1,21 +1,40 @@
 <script>
 
+  var ready = function (fn) {
+
+    // Sanity check
+    if (typeof fn !== 'function') return;
+
+    // If document is already loaded, run method
+    if (document.readyState === 'complete') {
+      return fn();
+    }
+
+    // Otherwise, wait until document is loaded
+    document.addEventListener('DOMContentLoaded', fn, false);
+
+  };
+
+  ready(function () {
+
     // Media query event handler
     if (matchMedia) {
-      var details = document.querySelector('#tutorial-resources');
+      var menu = document.querySelector('#tutorial-resources');
       var mq = window.matchMedia('(min-width: 62em)');
       mq.addListener(mm);
       mm(mq);
     }
-    
+
     // Media query change
     function mm(mq) {
       if (mq.matches) {
-        details.setAttribute('open', 'open');
+        menu.setAttribute('open', 'open');
       }
       else {
-        details.removeAttribute('open');
+        menu.removeAttribute('open');
       }
     }
+
+  });
 
 </script>

--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -17,6 +17,7 @@
 
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
+{% include take5/detail-opener-js.html %}
 {% assign course = site.data.take5s[page.course_ID] %}
 
 <main id="main" role="main">
@@ -181,7 +182,6 @@
     {% endif %}
 </main>
 
-{% include take5/detail-opener-js.html %}
 
 {%- if jekyll.environment == "development" -%}
     {%- include take5/test-bottom.html -%}

--- a/_layouts/take5-raw.html
+++ b/_layouts/take5-raw.html
@@ -17,7 +17,6 @@
 
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
-{% include take5/detail-opener-js.html %}
 {% assign course = site.data.take5s[page.course_ID] %}
 
 <main id="main" role="main">
@@ -182,6 +181,7 @@
     {% endif %}
 </main>
 
+{% include take5/detail-opener-js.html %}
 
 {%- if jekyll.environment == "development" -%}
     {%- include take5/test-bottom.html -%}

--- a/take5/catalog-blitz.html
+++ b/take5/catalog-blitz.html
@@ -27,6 +27,8 @@ permalink: /static/take5/
 
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
+{% include take5/detail-opener-js.html %}
+
 <main id="main" role="main">
 <header class="take5--about" id="about">
   <div class="container">
@@ -192,8 +194,6 @@ permalink: /static/take5/
 {%- endif -%}
 
 </main>
-
-{% include take5/detail-opener-js.html %}
 
 {%- if jekyll.environment == "development" -%}
     {%- include take5/test-bottom.html -%}

--- a/take5/catalog-blitz.html
+++ b/take5/catalog-blitz.html
@@ -27,8 +27,6 @@ permalink: /static/take5/
 
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/take5.css">
 
-{% include take5/detail-opener-js.html %}
-
 <main id="main" role="main">
 <header class="take5--about" id="about">
   <div class="container">
@@ -53,7 +51,7 @@ permalink: /static/take5/
 {%- assign pubdates_sorted = pubdates | sort -%}
 
 {%- for pubdate in pubdates_sorted -%}
-    
+
     {% for take5_hash in catalog %}
         {% assign item = take5_hash[1] %}
         {%- if item.date == pubdate -%}
@@ -89,11 +87,11 @@ permalink: /static/take5/
 {%- endif -%}
 {%- endfor -%}
 
- 
+
 
 {% if featured != null %}
 <div class="take5--main">
-    
+
 <div class="take5--hero-content">
     <div class="container">
         <div class="row">
@@ -125,7 +123,7 @@ permalink: /static/take5/
 <details open class="take5--resources" id="tutorial-resources">
         <summary aria-expanded="true/false" tabindex="0" role="button"><b role="heading">Upcoming</b></summary>
             <div class="take5--resources-list take5--upcoming-list">
-            <ul>    
+            <ul>
     {%- for item in upcoming limit: 5 -%}
     {%- assign upcoming_take5 = site.data.take5s[item] -%}
 
@@ -134,8 +132,8 @@ permalink: /static/take5/
     {{ upcoming_take5.date | date: "%b %-d" }}</time>
     <h4>{{ upcoming_take5.title }}</h4>
     </li>
-    
-    
+
+
     {%- endfor -%}
             </ul>
         <p><strong>Stay Up-To-Date</strong><br><a class="gymlink" href="https://twitter.com/aquentgymnasium" target="_blank" rel="noopener">Follow Gymnasium on Twitter</a></p>
@@ -194,6 +192,8 @@ permalink: /static/take5/
 {%- endif -%}
 
 </main>
+
+{% include take5/detail-opener-js.html %}
 
 {%- if jekyll.environment == "development" -%}
     {%- include take5/test-bottom.html -%}


### PR DESCRIPTION
This PR does the following:

Loads script when content is loaded and adds an open attribute to the Resources section (details element) to keep the section expanded (not collapsed) within a multi-column layout view if previously closed (collapsed) during a session within a smaller, single-column layout view.

For example:

1. When viewed on a tablet in the portrait orientation, the Resources section is open by default
2. When viewed on a tablet in the portrait orientation, the Resources section can be toggled to closed
3. Then changing orientation from portrait to landscape, the Resources section remains closed
4. Intended behavior is for the Resources section to re-open in a multi-column layout view

Detailed example:

1. Resources section is open by default:

![gym-resources-open-tablet-portrait](https://user-images.githubusercontent.com/5142085/69237056-ccdda600-0b62-11ea-9056-4955d90aea37.png)

2. Resources section can be toggled to closed:

![gym-resources-closed-tablet-portrait](https://user-images.githubusercontent.com/5142085/69237151-044c5280-0b63-11ea-95c4-dc083d8cd73e.png)

3. Change orientation, from portrait to landscape, for a multi-column view:

![gym-resources-closed-tablet-landscape](https://user-images.githubusercontent.com/5142085/69237226-2fcf3d00-0b63-11ea-85a8-05e832f3c449.png)

4. Intended behavior:

![gym-resources-open-tablet-landscape](https://user-images.githubusercontent.com/5142085/69237247-3b226880-0b63-11ea-81e6-835b6bfc2568.png)







