### PR TITLE
Update recommended content subhead markup and style

### DIFF
--- a/_includes/take5/recommended-content.html
+++ b/_includes/take5/recommended-content.html
@@ -47,21 +47,21 @@
 {%- assign this_topic = site.data.take5s.[page.course_ID].topic -%}
 
 {% assign sorted_catalog = site.data.take5s | sort %}
-  
+
 {% for take5_hash in sorted_catalog reversed %}
-  
+
   {% assign item = take5_hash[1] %}
-  
+
   {% if item.topic == this_topic %}
-  
+
         {% if item.live == true %}
             {% if item.course_ID != this_tutorial %}
               {%- assign recommendations = recommendations | push: item.course_ID -%}
             {% endif %}
-        {% endif %}  
-      {% endif %}  
+        {% endif %}
+      {% endif %}
   {% endfor %}
- 
+
  {%- assign random_recommendations = recommendations | sample: 3 -%}
 
  {%- assign rec1 = random_recommendations[0] -%}
@@ -94,7 +94,7 @@
                 </a>
               </div>
               <header>
-                <b class="all-caps">{{ tutorial1.topic }}</b>
+                <h4 class="subhead-topic">{{ tutorial1.topic }}</h4>
                 <h3 class="all-caps">
                   <a href="{{ tutorial1.title | slugify | prepend: domain_link  }}">{{ tutorial1.title }}</a>
                 </h3>
@@ -109,7 +109,7 @@
                 </a>
               </div>
               <header>
-                <b class="all-caps">{{ tutorial2.topic }}</b>
+                <h4 class="subhead-topic">{{ tutorial2.topic }}</h4>
                 <h3 class="all-caps">
                   <a href="{{ tutorial2.title | slugify | prepend: domain_link  }}">{{ tutorial2.title }}</a>
                 </h3>
@@ -121,10 +121,10 @@
               <div class="artwork" data-duration="{{ tutorial3.video_duration }}">
                 <a href="{{ tutorial3.title | slugify | prepend: domain_link  }}" title="Watch Video">
                   <img alt="{{ tutorial3.title }}" src="{{ site.url }}{{ site.baseurl }}{{ tutorial3.poster_art }}">
-                </a>
+                </a>s
               </div>
               <header>
-                <b class="all-caps">{{ tutorial3.topic }}</b>
+                <h4 class="subhead-topic">{{ tutorial3.topic }}</h4>
                 <h3 class="all-caps">
                   <a href="{{ tutorial3.title | slugify | prepend: domain_link  }}">{{ tutorial3.title }}</a>
                 </h3>

--- a/css/take5.css
+++ b/css/take5.css
@@ -352,7 +352,6 @@ main h3 {
 #main .take5--recommended h2 {
   font-size: 1.55em;
   letter-spacing: .035rem;
-
 }
 
 .course header,
@@ -377,6 +376,11 @@ main h3 {
 
 .tutorial .subhead-topic {
   font-weight: 900;
+}
+
+.take5--recommended .tutorial .subhead-topic {
+  margin-top: 1.6rem;
+  margin-bottom: .8rem;
 }
 
 .subhead-datetime {


### PR DESCRIPTION
This PR does:

Updates the correct display of the topics subheading (as shown below).

Before:

![subhead-style-before](https://user-images.githubusercontent.com/5142085/69763486-4c5b0e80-113b-11ea-9c82-c9c47b012ba7.png)

After:

![subhead-style-after](https://user-images.githubusercontent.com/5142085/69763498-52e98600-113b-11ea-9576-4fe274dbd6cc.png)



