### PR TITLE
add missing meta stub files

### DIFF
--- a/take5/meta/gym-5023-meta.md
+++ b/take5/meta/gym-5023-meta.md
@@ -1,0 +1,5 @@
+---
+layout: take5-meta
+course_ID: GYM-5023
+permalink: /static/take5/meta/gym-5023-meta/
+---

--- a/take5/meta/gym-5024-meta.md
+++ b/take5/meta/gym-5024-meta.md
@@ -1,0 +1,5 @@
+---
+layout: take5-meta
+course_ID: GYM-5024
+permalink: /static/take5/meta/gym-5024-meta/
+---


### PR DESCRIPTION
## What this PR does:

- adds meta stub files for GYM-5023, GYM-5024
- provides partial includes for the associated edX container pages
  - **Staging**
    - https://staging.gymcms.xyz/static/take5/meta/gym-5023-meta/
    - https://staging.gymcms.xyz/static/take5/meta/gym-5024-meta/
  - **Production**
    - https://gymcms.xyz/static/take5/meta/gym-5023-meta/
    - https://gymcms.xyz/static/take5/meta/gym-5024-meta/