### PR TITLE
fix headshot paths and video IDs

### DIFF
--- a/_includes/event-video.html
+++ b/_includes/event-video.html
@@ -1,6 +1,6 @@
 {% if webinar.video_ID %}
 <div class="event-video">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ page.video_ID }}" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ webinar.video_ID }}" frameborder="0" allowfullscreen></iframe>
 </div>
 {% else %}
 <h2>No video ID provided</h2>

--- a/_includes/webinar-bio.html
+++ b/_includes/webinar-bio.html
@@ -11,7 +11,7 @@
     {%- assign headshot = bio.headshot -%}
 {%- endif -%}
 <section class="event-bio">
-    <img alt="{{ bio.name }}" src="{{ site.baseurl }}/img/webinar-bio-headshots/{{ headshot }}">
+    <img alt="{{ bio.name }}" src="{{ site.url }}{{ site.baseurl }}/img/webinar-bio-headshots/{{ headshot }}">
     <h2>{{ bio.name }}</h2>
     <p>
         {{ description }}


### PR DESCRIPTION
## What this PR does:

- Resolves gymnasium/tracker#32 (relative paths = broken headshots)
- Resolves gymnasium/tracker#33 (video embed not receiving a `video_ID`)
