### PR TITLE
Update webinar URL

### DIFF
--- a/_data/webinars/web0005-state-of-responsive-web-design.yml
+++ b/_data/webinars/web0005-state-of-responsive-web-design.yml
@@ -1,9 +1,9 @@
 ---
-event_ID: web0005-state-of-responsive-design
+event_ID: web0005-state-of-responsive-web-design
 event_title: "The State of Responsive Design"
 event_guests: "with Ethan Marcotte and <span class=\"nowrap\">Karen McGrane</span>"
 short_description: "A conversation about the past, present, and future state of responsive web design with special guests Ethan Marcotte and Karen McGrane."
-permalink: static/webinars/state-of-responsive-design
+permalink: static/webinars/state-of-responsive-web-design
 event_date: 2016-12-08
 event_time: "2PM EDT"
 event_ogimage: state-of-responsive-web-design-event-og.png

--- a/hub-pages/web-development/bottom.html
+++ b/hub-pages/web-development/bottom.html
@@ -437,11 +437,11 @@ permalink: /static/web-development-bottom/
             <section class="webinar">
               <figure>
                 <div class="poster-mask">
-                  <a href="https://thegymnasium.com/webinars/state-of-responsive-design" title="Watch Now"><img alt="The State of Responsive Design with Ethan Marcotte and Karen McGrane" src="{{ site.url }}{{ site.baseurl }}/img/hub-pages/webinars/posters/state-of-responsive-design.jpg"></a>
+                  <a href="https://thegymnasium.com/webinars/state-of-responsive-web-design" title="Watch Now"><img alt="The State of Responsive Design with Ethan Marcotte and Karen McGrane" src="{{ site.url }}{{ site.baseurl }}/img/hub-pages/webinars/posters/state-of-responsive-design.jpg"></a>
                 </div>
               </figure>
               <header>
-                <h3><a href="https://thegymnasium.com/webinars/state-of-responsive-design">The State of Responsive Design</a></h3>
+                <h3><a href="https://thegymnasium.com/webinars/state-of-responsive-web-design">The State of Responsive Design</a></h3>
               </header>
             </section>
           </li>

--- a/webinars/web0005-state-of-responsive-design.md
+++ b/webinars/web0005-state-of-responsive-design.md
@@ -1,5 +1,5 @@
 ---
-event_ID: web0005-state-of-responsive-design
-permalink: /static/webinars/state-of-responsive-design/
+event_ID: web0005-state-of-responsive-web-design
+permalink: /static/webinars/state-of-responsive-web-design/
 layout: webinar
 ---


### PR DESCRIPTION
## What this PR does:

- Renames the "state-of-responsive-design" webinar to "state-of-responsive-web-design" to match existing URL: https://thegymnasium.com/webinars/state-of-responsive-web-design
- Fixes webinar URL on Web Development collection page
