### PR TITLE
Address a webinar url inconsistency glitch

### DIFF
--- a/_layouts/meta.html
+++ b/_layouts/meta.html
@@ -5,10 +5,17 @@
     {%- assign event = site.data.webinars[page.event_ID] -%}
     {%- assign short_description = event.short_description | strip_html -%}
 
-    {%- assign path = event.event_ID -%}
-    {%- assign path =  path | slice: 8,path.size   -%}
-    {%- assign og_url = path | prepend: "https://thegymnasium.com/webinars/" -%}
-    {%- assign og_title = event.event_title -%}
+    {%- if event.event_ID == "web0005-state-of-responsive-web-design" -%}
+        {%- assign og_url = "https://thegymnasium.com/webinars/state-of-responsive-web-design" -%}
+        {%- assign og_title = event.event_title -%}
+    
+    {%- else -%}
+
+        {%- assign path = event.event_ID -%}
+        {%- assign path =  path | slice: 8,path.size   -%}
+        {%- assign og_url = path | prepend: "https://thegymnasium.com/webinars/" -%}
+        {%- assign og_title = event.event_title -%}
+    {%- endif -%}
 
     {%- if event.register == true -%}    
         {%- assign page_title = "Webinar Registration | The Gymnasium" -%}

--- a/tests/webinars-test.html
+++ b/tests/webinars-test.html
@@ -52,7 +52,12 @@ Webinar Count: {{ site.data.webinars | size }}
 <table>
 {%- for webinar in webinars_descending_date -%}
     {%- assign item = site.data.webinars[webinar] -%}
-    {%- assign gym_path = item.permalink | remove: "static/"-%}
+    
+    {%- if item.event_ID == "web0005-state-of-responsive-web-design" -%}
+        {%- assign gym_path = "webinars/state-of-responsive-web-design"-%}
+    {%- else -%}
+        {%- assign gym_path = item.permalink | remove: "static/"-%}
+    {%- endif -%}
     <tr>
         <td><strong>{{ item.event_title | strip_html }}</strong></td>
         <td><a href="{{ site.url }}{{ site.baseurl }}/{{ item.permalink }}" target="_blank">{{ site.url }}{{ site.baseurl }}/{{ item.permalink }}</a></td>

--- a/webinars/webinars.html
+++ b/webinars/webinars.html
@@ -44,15 +44,28 @@ layout: raw
       {%- assign speaker_1 = item.speaker[0]  -%}
       {%- assign speaker_2 = item.speaker[1]  -%}
 
-
-      {% case jekyll.environment %}
-        {% when "development" %}
-          {%- assign webinar_url = item.permalink | prepend: '/' | prepend: site.url  -%}
-        {% when "staging" %}
-          {%- assign webinar_url = item.permalink | remove_first: 'static'| prepend: 'https://courses.gymna.si' -%}
-        {% when "production" %}
-          {%- assign webinar_url = item.permalink | remove_first: 'static'| prepend: 'https://thegymnasium.com' -%}
-      {% endcase %}
+      {%- if item.event_ID == "web0005-state-of-responsive-web-design" -%}
+        {% case jekyll.environment %}
+          {% when "development" %}
+            {%- assign webinar_url = '/static/webinars/state-of-responsive-design'  -%}
+          {% when "staging" %}
+            {%- assign webinar_url = 'https://courses.gymna.si/webinars/state-of-responsive-web-design' -%}
+          {% when "production" %}
+            {%- assign webinar_url = 'https://thegymnasium.com/webinars/state-of-responsive-web-design' -%}
+        {% endcase %}
+      
+      {%- else -%}
+      
+        {% case jekyll.environment %}
+          {% when "development" %}
+            {%- assign webinar_url = item.permalink | prepend: '/' | prepend: site.url  -%}
+          {% when "staging" %}
+            {%- assign webinar_url = item.permalink | remove_first: 'static'| prepend: 'https://courses.gymna.si' -%}
+          {% when "production" %}
+            {%- assign webinar_url = item.permalink | remove_first: 'static'| prepend: 'https://thegymnasium.com' -%}
+        {% endcase %}
+      
+      {%- endif -%}
 
 
       {% if item.register %}


### PR DESCRIPTION
## What this PR does:

- solves a problem with one specific webinar — The State of Responsive _Web_ Design
- wherever paths are derived from webinar permalinks, we address this specific case
- Resolves gymnasium/tracker#34

### Testing Notes

- Verify link to this webinar on /webinars/
  - Local build: `http://0.0.0.0:4000/static/webinars/state-of-responsive-design/`
  - Deploy preview: `https://thegymnasium.com/webinars/state-of-responsive-web-design`

- Verify associated meta include `/static/webinars/meta/state-of-responsive-design/`