### PR TITLE
Update Take 5 hero layout

### DIFF
--- a/_includes/take5/hero-take5-featured.html
+++ b/_includes/take5/hero-take5-featured.html
@@ -23,8 +23,6 @@
     {%- endif -%}
 {%- endfor -%}
 
-
-
 {%- case hero_topic -%}
     {%- when "Web Design & Development" -%}
     {%- assign hero_style = "topic-web-design-development" -%}
@@ -40,7 +38,6 @@
 
 {%- endcase -%}
 
-
 <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/hero-take5.css">
   <div class="{{ 'hero-promo' }} {{ hero_style }}" id="hero-{{ hero_ID }}">
   <div class="container">
@@ -48,7 +45,7 @@
     <div class="hero-content-copy">
       <header>
         <h3 class="subhead-topic">{{ hero_topic }}</h3>
-        <h2><span class="take5-brand-kern">Take 5</span></h2>
+        <h2 class="take5-brand-kern">Take 5</h2>
         <h1>{{ hero_title }}</h1>
         <p class="description"><strong>Take 5 minutes to learn a practical skill for free.</strong></p>
       </header>

--- a/css/hero-take5.css
+++ b/css/hero-take5.css
@@ -33,9 +33,9 @@
 
   .hero-promo .container {
     position: relative;
-    left: 10%;
-    max-width: 43.5em;
+    left: 17%;
     box-sizing: content-box;
+    max-width: 37em;
     min-height: 25.125em;
   }
 
@@ -50,7 +50,6 @@
     background-repeat: no-repeat;
     background-position: left center;
     background-size: cover;
-    border-right: 2px solid #ccc;
     border-image-slice: 1;
     border-image-width: 0 0 0 999em;
     border-image-repeat: stretch;


### PR DESCRIPTION
## What this PR does:

Updates Take 5 home page hero layout to better display in a wider range of viewports with a more well-proportioned artwork to copy ratio.

- - -

### Before & After

#### Before @ 1024w (2x)

![hero-take5-1024w-2x-before](https://user-images.githubusercontent.com/5142085/77183689-1c969480-6aa5-11ea-8a75-30fd832be4d6.png)

#### After @ 1024w (2x)

![hero-take5-1024w-2x-after](https://user-images.githubusercontent.com/5142085/77183668-14d6f000-6aa5-11ea-96de-cd597ce47e3b.png)

#### Before @ 1280w (2x)

![hero-take5-1280w-2x-before](https://user-images.githubusercontent.com/5142085/77183703-24563900-6aa5-11ea-8550-bb8ba1f9102b.png)

#### After @ 1280w (2x)

![hero-take5-1280w-2x-after](https://user-images.githubusercontent.com/5142085/77183835-52d41400-6aa5-11ea-91e8-b7b602a6cfb8.png)

#### Before @ 1440w (2x)

![hero-take5-1440w-2x-before](https://user-images.githubusercontent.com/5142085/77183875-59fb2200-6aa5-11ea-82f5-e130a5da318c.png)

#### After @ 1440w (2x)

![hero-take5-1440w-2x-after](https://user-images.githubusercontent.com/5142085/77183896-5ff10300-6aa5-11ea-9f9e-0d8456b168cb.png)

#### After With Other Take 5 Heros

#### After @ 1440w (2x)

![hero-take5-5029-1440w-2x](https://user-images.githubusercontent.com/5142085/77183929-6aab9800-6aa5-11ea-9f44-d353534d4174.png)

#### After @ 1440w (2x)

![hero-take5-5028-1440w-2x](https://user-images.githubusercontent.com/5142085/77183947-71d2a600-6aa5-11ea-8d49-255520190d98.png)

#### After @ 1440w (2x)

![hero-take5-5027-1440w-2x](https://user-images.githubusercontent.com/5142085/77183965-78611d80-6aa5-11ea-9d9a-1abebe83c6ee.png)

- - -

Resolves: https://github.com/gymnasium/tracker/issues/35