### PR TITLE
Fix missing content in collection page metas

### DIFF
--- a/_layouts/meta.html
+++ b/_layouts/meta.html
@@ -36,13 +36,25 @@
     {%- assign course = site.data.take5s[page.course_ID] -%}
     {%- assign og_description = course.short_description -%}
     {%- assign og_url = course.title | slugify | prepend: "https://thegymnasium.com/take5/" -%}
-    {%- assign page_title content="Take 5 | Gymnasium" -%}
+    {%- assign page_title = "Take 5 | Gymnasium" -%}
     {%- assign og_art = course.course_ID | downcase | append: "-og.png" | prepend: "/img/take5/og/" -%}
     {%- assign og_alt = course.title | prepend: "Video poster for tutorial titled " -%}
 
+{%- elsif page.permalink contains "hub-pages" -%}
+    {%- comment -%}
+    Set up meta tags for a collection or hub page meta include
+    {%- endcomment -%}
+    {%- assign short_description = page.og_description -%}
+    {%- assign og_url = page.og_url -%}
+    {%- assign page_title = page.page_title -%}
+    {%- assign og_art = page.og_art -%}
+    {%- assign og_alt = page.og_title -%}
+    {%- assign og_title = page.og_title -%}
+
+
 {%- endif -%}
     
-<meta name="description" content="{{ short_description }}">
+<meta name="description" content="{{ short_description | strip_html }}">
 <meta name="author" content="Aquent Gymnasium">
 <meta property="og:url" content="{{ og_url }}">
 <meta property="og:type" content="website">

--- a/hub-pages/career-skills/meta.md
+++ b/hub-pages/career-skills/meta.md
@@ -1,7 +1,7 @@
 ---
 layout: meta
 permalink: /static/hub-pages/meta/career-skills-collection-meta/
-og_description: "Explore our free collection of UX courses, tutorials, webinars, articles, and jobs."
+og_description: "Explore our free collection of career skill courses, tutorials, webinars, articles, and jobs."
 og_title: "Career Skills Collection"
 og_url: https://thegymnasium.com/career-skills
 page_title: "Career Skills | Gymnasium"

--- a/hub-pages/prototyping/meta.md
+++ b/hub-pages/prototyping/meta.md
@@ -1,7 +1,7 @@
 ---
 layout: meta
 permalink: /static/hub-pages/meta/prototyping-collection-meta/
-og_description: "Explore our free collection of UX courses, tutorials, webinars, articles, and jobs."
+og_description: "Explore our free collection of prototyping courses, tutorials, webinars, articles, and jobs."
 og_title: "Prototyping Collection"
 og_url: https://thegymnasium.com/prototyping
 page_title: "Prototyping | Gymnasium"

--- a/hub-pages/prototyping/meta.md
+++ b/hub-pages/prototyping/meta.md
@@ -5,5 +5,5 @@ og_description: "Explore our free collection of UX courses, tutorials, webinars,
 og_title: "Prototyping Collection"
 og_url: https://thegymnasium.com/prototyping
 page_title: "Prototyping | Gymnasium"
-og_art: /img/hub-pages/og/prototyping-collection-og.png
+og_art: img/hub-pages/og/prototyping-collection-og.png
 ---

--- a/hub-pages/remote-work/meta.md
+++ b/hub-pages/remote-work/meta.md
@@ -5,5 +5,5 @@ og_description: "Explore our free collection resources for remote work."
 og_title: "Remote Work Resources"
 og_url: https://thegymnasium.com/remote-work
 page_title: "Remote Work | Gymnasium"
-og_art: /img/hub-pages/og/remote-work-og.png
+og_art: img/hub-pages/og/remote-work-og.png
 ---

--- a/hub-pages/ux-design/meta.md
+++ b/hub-pages/ux-design/meta.md
@@ -5,5 +5,5 @@ og_description: "Explore our free collection of UX courses, tutorials, webinars,
 og_title: "UX Design Collection"
 og_url: https://thegymnasium.com/ux-design
 page_title: "UX Design | Gymnasium"
-og_art: /img/hub-pages/og/ux-design-collection-og.png
+og_art: img/hub-pages/og/ux-design-collection-og.png
 ---

--- a/hub-pages/web-development/meta.md
+++ b/hub-pages/web-development/meta.md
@@ -5,5 +5,5 @@ og_description: "Explore our free collection of UX courses, tutorials, webinars,
 og_title: "Web Development Collection"
 og_url: https://thegymnasium.com/web-development
 page_title: "Web Development | Gymnasium"
-og_art: /img/hub-pages/og/web-development-collection-og.png
+og_art: img/hub-pages/og/web-development-collection-og.png
 ---

--- a/hub-pages/web-development/meta.md
+++ b/hub-pages/web-development/meta.md
@@ -1,7 +1,7 @@
 ---
 layout: meta
 permalink: /static/hub-pages/meta/web-development-collection-meta/
-og_description: "Explore our free collection of UX courses, tutorials, webinars, articles, and jobs."
+og_description: "Explore our free collection of web development courses, tutorials, webinars, articles, and jobs."
 og_title: "Web Development Collection"
 og_url: https://thegymnasium.com/web-development
 page_title: "Web Development | Gymnasium"

--- a/tests/collections.html
+++ b/tests/collections.html
@@ -15,7 +15,7 @@ permalink: tests/collections/
 <h2>Meta Partial Includes</h2>
 <ul>
     <li><a href="/static/hub-pages/meta/career-skills-collection-meta/">Career Skills</a></li>
-    <li><a href="/static/hub-pages/meta/prototyping/">Prototyping Collection Meta</a></li>
+    <li><a href="/static/hub-pages/meta/prototyping-collection-meta/">Prototyping Collection Meta</a></li>
     <li><a href="/static/hub-pages/meta/ux-design-collection-meta/">UX Collection Meta</a></li>
     <li><a href="/static/hub-pages/meta/web-development-collection-meta/">Web Development Collection Meta</a></li>
 </ul>


### PR DESCRIPTION
## This PR:

- _Should have_ had placeholder pages for the remote work hub page but 🤠 happened
- fixes a problem with missing meta field values for other collection pages that are using the meta layout
- resolves gymnasium/tracker#37

### Testing this PR:

- https://deploy-preview-382--thegymcms.netlify.com/tests/remote-work/
  - https://deploy-preview-382--thegymcms.netlify.com/static/remote-work-top
  - https://deploy-preview-382--thegymcms.netlify.com/static/remote-work-bottom
  - https://deploy-preview-382--thegymcms.netlify.com/static/hub-pages/meta/remote-work-meta/
