### PR TITLE
Update text color and contrast ratio

### DIFF
--- a/css/hub-pages.css
+++ b/css/hub-pages.css
@@ -70,6 +70,10 @@ main figcaption {
   margin-bottom: 0;
 }
 
+#main .main-content p {
+  color: #555;
+}
+
 /* typographical details */
 
 #main .all-caps {
@@ -229,6 +233,7 @@ main figcaption {
 
 #about p {
   font: normal 1.25em/1.45 "Helvetica Neue", Helvetica, sans-serif;
+  color: #222;
   margin-top: .6em;
 }
 
@@ -240,10 +245,6 @@ main figcaption {
 main h3 {
   font-size: 1.4em;
   line-height: 1.35;
-}
-
-#main .section header p {
-  color: #444;
 }
 
 /* --- section --- */
@@ -267,6 +268,10 @@ main h3 {
 .section-content > header {
   margin-top: .4em;
   margin-bottom: 1.6em;
+}
+
+#main .section-content > header p {
+  color: #222;
 }
 
 .section-content section header {


### PR DESCRIPTION
## What this PR does:

Updates paragraph text color and contrast ratio overrides for readability and accessibility (to pass a11y guidelines instead of failing for lighter gray text) on hub pages in general, but more specifically on the recent Remote Work resources page.

**Before:**

**Staging/Production**

High contrast text style (passes a11y guidelines).

![remote-work-paragraph-contrast-staging-production](https://user-images.githubusercontent.com/5142085/81614293-d4f9fe00-93ad-11ea-8914-9ea22d16e0f1.png)

**Local Environment**

Low contrast text style (intended color, but contrast fails a11y guidelines).

![remote-work-paragraph-contrast-local-env](https://user-images.githubusercontent.com/5142085/81614322-e2af8380-93ad-11ea-9fd1-63515b0de9ea.png)

**After:**

**Contrast Style Update**

Medium contrast text style (compromise for color and contrast, passes a11y guidelines).

![remote-work-paragraph-contrast-update](https://user-images.githubusercontent.com/5142085/81614360-f4912680-93ad-11ea-8924-40635fda099d.png)
