### PR TITLE
Update webinars available soon text style

### DIFF
--- a/css/webinars.css
+++ b/css/webinars.css
@@ -259,6 +259,10 @@ main figcaption {
   padding: 1.2em;
 }
 
+.webinar--cta p {
+  font-size: 1em;
+}
+
 /* --- featured webinar --- */
 
 #featured-webinar header,

--- a/css/webinars.css
+++ b/css/webinars.css
@@ -260,6 +260,7 @@ main figcaption {
 
 .webinar--cta p {
   font-size: 1em;
+  margin-top: 0;
 }
 
 /* --- featured webinar --- */

--- a/css/webinars.css
+++ b/css/webinars.css
@@ -255,7 +255,6 @@ main figcaption {
 
 .webinar--cta {
   color: #fff;
-  align-items: end;
   padding: 1.2em;
 }
 
@@ -828,8 +827,4 @@ main aside h2 {
 .event-bio h2 {
   margin-top: 1.3em;
   margin-bottom: .8em;
-}
-
-.event-thumb {
-  max-width: 200px;
 }

--- a/webinars/webinars.html
+++ b/webinars/webinars.html
@@ -128,7 +128,7 @@ layout: raw
               <b>Watch Recording</b>
             </a>
             {% else %}
-            <strong>Recording available soon…</strong>
+            <p><strong>Recording available soon…</strong></p>
             {%- endif -%}
           </div>
         </div>


### PR DESCRIPTION
## What this PR does:

Updates `/webinars` “Recording available soon…” text structure and style to correctly display as sans-serif instead of serif (in some cases, as documented).

**Issue: Unexpected Appearance (Serif)**

![webinars-recording-coming-soon-serif](https://user-images.githubusercontent.com/5142085/83194993-836ca580-a107-11ea-8a46-ab8c2083dcba.png)

**Resolve: Expected Appearance (Sans-serif)**

![webinars-recording-coming-soon-sans-serif](https://user-images.githubusercontent.com/5142085/83199066-756e5300-a10e-11ea-880f-9817b08bea34.png)


