### PR TITLE
fix rendering glitch on hub pages

### DIFF
--- a/hub-pages/career-skills/test.html
+++ b/hub-pages/career-skills/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/collections/career-skills/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}

--- a/hub-pages/prototyping/test.html
+++ b/hub-pages/prototyping/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/collections/prototyping/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}

--- a/hub-pages/remote-work/test.html
+++ b/hub-pages/remote-work/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/remote-work/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}

--- a/hub-pages/ux-design/test.html
+++ b/hub-pages/ux-design/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/collections/ux-design/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}

--- a/hub-pages/web-development/test.html
+++ b/hub-pages/web-development/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/collections/web-development/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}

--- a/jobs/test.html
+++ b/jobs/test.html
@@ -1,6 +1,0 @@
----
-layout: test-home-minimal
-permalink: /tests/jobs/
----
-{%- include_relative top.html -%}
-{%- include_relative bottom.html -%}


### PR DESCRIPTION
## What this PR does:

- Removes `test.html` from all hub pages

### To test:

- verify that [`ux-design-top`](https://deploy-preview-445--thegymcms.netlify.app/static/ux-design-top)* has no visible front-matter in the rendered page



---
\* ...or `/static/remote-work-top`, `/static/prototyping-top`, `/static/jobs-top`, etc
