### PR TITLE
Remove redirection script from cms test pages

### DIFF
--- a/_layouts/test-footer-minimal.html
+++ b/_layouts/test-footer-minimal.html
@@ -8,14 +8,6 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title> Home | Free online courses on design and software development | Gymnasium </title>
-	<script type="text/javascript">
-		/* immediately break out of an iframe if coming from the marketing website */
-		(function(window) {
-		  if (window.location !== window.top.location) {
-		    window.top.location = window.location;
-		  }
-		})(this);
-	</script>
 	<script type="text/javascript" src="https://thegymnasium.com/static/js/i18n/en/djangojs.b28203373cc1.js">
 	</script>
 	<link rel="icon" type="image/x-icon" href="https://thegymnasium.com/static/gymnasium/images/favicon.f729730b6e79.ico" />

--- a/_layouts/test-home-minimal.html
+++ b/_layouts/test-home-minimal.html
@@ -8,14 +8,6 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title> Home | Free online courses on design and software development | Gymnasium </title>
-	<script type="text/javascript">
-		/* immediately break out of an iframe if coming from the marketing website */
-		(function(window) {
-		  if (window.location !== window.top.location) {
-		    window.top.location = window.location;
-		  }
-		})(this);
-	</script>
 	<script type="text/javascript" src="https://thegymnasium.com/static/js/i18n/en/djangojs.b28203373cc1.js">
 	</script>
 	<link rel="icon" type="image/x-icon" href="https://thegymnasium.com/static/gymnasium/images/favicon.f729730b6e79.ico" />

--- a/_layouts/test-home.html
+++ b/_layouts/test-home.html
@@ -8,14 +8,6 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title> Home | Free online courses on design and software development | Gymnasium </title>
-	<script type="text/javascript">
-		/* immediately break out of an iframe if coming from the marketing website */
-		(function(window) {
-		  if (window.location !== window.top.location) {
-		    window.top.location = window.location;
-		  }
-		})(this);
-	</script>
 	<script type="text/javascript" src="https://thegymnasium.com/static/js/i18n/en/djangojs.b28203373cc1.js">
 	</script>
 	<link rel="icon" type="image/x-icon" href="https://thegymnasium.com/static/gymnasium/images/favicon.f729730b6e79.ico" />


### PR DESCRIPTION
## What this PR does:

- removes a few instances of a script that forces the page to break out of an iframe

### To test:

- http://ami.responsivedesign.is/?url=https://deploy-preview-457--thegymcms.netlify.app/tests/hero
- the result should not redirect (or display redirection errors)
