### PR TITLE
Update cookie banner style

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -81,6 +81,45 @@ permalink: /static/system-status/
 }
 
 /* ---
+https://github.com/gymnasium/tracker/issues/77
+--- */
+
+.cookiebanner {
+  border-top: 1px dashed #666;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
+}
+
+@media (max-width: 75em) {
+
+  .cookiebanner {
+    text-align: left !important;
+  }
+
+}
+
+.cookiebanner span {
+  color: #fff;
+}
+
+.cookiebanner a {
+  color: #fff !important;
+  padding-bottom: 0.125rem;
+  border-bottom: 1px solid currentColor !important;
+  margin-bottom: -0.125rem;
+}
+
+.cookiebanner a:hover,
+.cookiebanner a:focus,
+.cookiebanner a:active {
+  border-bottom-width: 2px !important;
+}
+
+.cookiebanner-close {
+  color: var(--gym-orange);
+}
+
+/* ---
 https://github.com/gymnasium/tracker/issues/54
 --- */
 


### PR DESCRIPTION
## What this PR does:

- Adds breakpoint to avoid centered text on smaller viewports
- Adds top dashed border and top/bottom padding to visually separate banner from page content
- Updates banner close button text color for better contrast ratio
- Updates banner text color for better contrast ratio
- Updates Privacy Policy link text style for better contrast ratio
- - -
- Resolves https://github.com/gymnasium/tracker/issues/77

**Before**

![gym-cookierbanner-wide-width-text-center-before](https://user-images.githubusercontent.com/5142085/89819456-7f063500-db19-11ea-9873-5183561a6055.png)
![gym-cookierbanner-small-width-text-center-before](https://user-images.githubusercontent.com/5142085/89819466-8299bc00-db19-11ea-85f1-c1997fd43011.png)

**After**

![gym-cookierbanner-wide-width-text-center-after](https://user-images.githubusercontent.com/5142085/89819515-934a3200-db19-11ea-95f2-ccf143586bc2.png)
![gym-cookierbanner-small-width-text-left-after](https://user-images.githubusercontent.com/5142085/89819523-95ac8c00-db19-11ea-8580-968cc4320264.png)



