### PR TITLE
Feed SurveyMonkey course ID as a url parameter

### DIFF
--- a/final-exam-modal-top.html
+++ b/final-exam-modal-top.html
@@ -45,3 +45,11 @@ permalink: /static/final-exam-modal-top/
     </div>
   </div>
 </main>
+
+<script type="text/javascript">
+  // append the course ID to the surveymonkey survey as a URL parameter
+  $(() => {
+    const COURSE_NUM = $('#__course_number__').text();
+    $('.survey a')[0].href += `?cid=${COURSE_NUM}`;
+  })
+</script>


### PR DESCRIPTION
To test (before deployment):

1. pull up a _final exam_ which you've passed already, like [this one](https://www.thegymnasium.com/courses/GYM/106/0/courseware/24881233cd0040d886dc2bbcca180101/db7ce249f281485085ca1ca0305f6dca/)
2. open your browser's devtools, and in the console, execute the following 2 lines:
```es6
  const COURSE_NUM = $('#__course_number__').text();
  $('.survey a')[0].href += `?cid=${COURSE_NUM}`;
```

hover over the `Take our Survey` button - its URL should have the course number appended as `?cid=109` etc. 🍰 