### PR TITLE
Fix course syllabus layout breakpoint

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -81,6 +81,42 @@ permalink: /static/system-status/
 }
 
 /* ---
+https://github.com/gymnasium/tracker/issues/81
+--- */
+
+/* syllabus / add single-column breakpoint fix */
+
+@media (max-width: 62em) {
+
+  #main .info-wrapper .updates {
+    padding-bottom: 0;
+    border-right: 0;
+  }
+
+  #main .info-wrapper .handouts {
+    display: block;
+    width: 100%;
+    padding-bottom: 2em;
+    border-top: 1px dashed #ccc;
+  }
+
+}
+
+/* dashboard / update single-column layout style */
+
+@media (max-width: 62em) {
+
+  #dashboard-main #my-courses {
+    border-right: 0;
+  }
+
+  #dashboard-main .profile-sidebar {
+    border-top: 1px dashed #ccc;
+  }
+
+}
+
+/* ---
 https://github.com/gymnasium/tracker/issues/77
 --- */
 


### PR DESCRIPTION
## What this PR does:

- Adds Syllabus single-column layout breakpoint for table-layout awesomeness
- Updates Dashboard single-column layout style
- - -
- Resolves: https://github.com/gymnasium/tracker/issues/81

### Syllabus Single-Column Breakpoint Fix

![gym-lms-syllabus-add-single-col-breakpoint](https://user-images.githubusercontent.com/5142085/94311060-9faf1080-ff48-11ea-8468-0cb5cb529e1b.png)

### Dashboard Single-Column Breakpoint Update

**Before**

![gym-lms-dashboard-single-col-breakpoint-before](https://user-images.githubusercontent.com/5142085/94311001-85753280-ff48-11ea-8e2a-347ebd15fff2.png)

**After**

![gym-lms-dashboard-single-col-breakpoint-after](https://user-images.githubusercontent.com/5142085/94311029-90c85e00-ff48-11ea-8126-555909256202.png)


