### PR TITLE
Update color contrast ratio related style

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -139,6 +139,37 @@ https://github.com/gymnasium/tracker/issues/81
 }
 
 /* ---
+https://github.com/gymnasium/tracker/issues/85
+--- */
+
+/* update (text) link style */
+
+#content a:not([class]) {
+  line-height: inherit;
+  color: currentColor !important;
+  text-decoration: none;
+  padding-bottom: 0.125rem;
+  border-bottom: 1px solid currentColor !important;
+}
+
+#content a:not([class]):hover,
+#content a:not([class]):focus,
+#content a:not([class]):active {
+ border-bottom-width: 2px !important;
+ margin-bottom: -0.125rem;
+}
+
+/*--
+https://github.com/gymnasium/tracker/issues/84
+--*/
+
+/* update color contrast ratio */
+
+#content .how-gymnasium-works p {
+  color: #666;
+}
+
+/* ---
 https://github.com/gymnasium/tracker/issues/77
 --- */
 


### PR DESCRIPTION
## What this PR does:

Updates color contrast ratio related style for improved accessibility.

- Updates in-page orange link style for front-end-esque pages
  - Fixes  https://github.com/gymnasium/tracker/issues/85

![gym-about-in-page-link](https://user-images.githubusercontent.com/5142085/95788718-0acb4780-0caa-11eb-8046-09c115f25340.png)

- Updates color contrast ratio for How Gymnasium Works body text
  - Fixes https://github.com/gymnasium/tracker/issues/84

![how-gym-works-text-color-contrast](https://user-images.githubusercontent.com/5142085/95788724-0d2da180-0caa-11eb-980a-8c2983656733.png)
