### PR TITLE
Update catalog in-page navigation link focus style

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -155,8 +155,15 @@ https://github.com/gymnasium/tracker/issues/85
 #content a:not([class]):hover,
 #content a:not([class]):focus,
 #content a:not([class]):active {
- border-bottom-width: 2px !important;
- margin-bottom: -0.125rem;
+  border-bottom-width: 2px !important;
+  margin-bottom: -0.125rem;
+}
+
+/* update font-family for catalog navigation */
+
+#gym-catalog .course-menu a:focus,
+#gym-catalog .course-menu a:active {
+  font-family: "brandon-grotesque", "Helvetica Neue", Helvetica, sans-serif;
 }
 
 /*--


### PR DESCRIPTION
## What this PR does:

Updates focus state font style for catalog navigation for Full Courses, Gym Shorts, Take 5 links.

See https://thegymnasium.com/courses for testing focus state.

- Updates link focus state font style for catalog navigation; replace generic sans-serif with Brandon Grotesque
- Updates ruleset indentation