### PR TITLE
Update text link style

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -144,7 +144,8 @@ https://github.com/gymnasium/tracker/issues/85
 
 /* update (text) link style */
 
-#content a:not([class]) {
+#content p > a:not([class]),
+#content li > a:not([class])  {
   line-height: inherit;
   color: currentColor !important;
   text-decoration: none;
@@ -152,9 +153,12 @@ https://github.com/gymnasium/tracker/issues/85
   border-bottom: 1px solid currentColor !important;
 }
 
-#content a:not([class]):hover,
-#content a:not([class]):focus,
-#content a:not([class]):active {
+#content p > a:not([class]):hover,
+#content p > a:not([class]):focus,
+#content p > a:not([class]):active,
+#content li > a:not([class]):hover,
+#content li > a:not([class]):focus,
+#content li > a:not([class]):active {
   border-bottom-width: 2px !important;
   margin-bottom: -0.125rem;
 }


### PR DESCRIPTION
## What this PR does:

Updates text link style; excludes style update for links nested in headings.

**To avoid:**

![gym-headings-as-links](https://user-images.githubusercontent.com/5142085/95797450-91d5eb00-0cbd-11eb-99d7-f1d89deb5a76.png)



