### PR TITLE
Switch home page and footer copy to match new slogan

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -17,7 +17,7 @@ permalink: /static/footer/
                   <img class="gymnasium-logo" alt="Aquent Gymnasium" src="{{ site.url }}{{ site.baseurl }}/img/brand/png/gymnasium-logo-white-4x.png" srcset="{{ site.url }}{{ site.baseurl }}/img/brand/svg/gymnasium-logo-white.svg" width="200" height="23" decoding="async">
                 </a>
               </div>
-              <p>Bridging the gap between education and opportunity with free online courses.</p>
+              <p>Design a career you love with free online courses.</p>
             </div>
           </div>
           <div class="col-xs-6 col-md-2 what-we-do">

--- a/home/featured-courses.html
+++ b/home/featured-courses.html
@@ -76,7 +76,7 @@ featured_courses: GYM-016, GYM-103, GYM-001, GYM-108
   </div>
   <div class="about-featured-courses">
     <div class="description">
-      <p>Gymnasium offers free online courses on web development, design, user experience, and content creation.</p>
+      <p>Design a career you love with free online courses on web design and development, user experience, accessibility, career skills, prototyping, and content creation.</p>
     </div>
     <div class="cta">
      <a class="gym-button" href="https://thegymnasium.com/courses"><b>View all Courses</b></a>


### PR DESCRIPTION
This PR contains 2 changes:

- update slogan copy below featured courses on home page to new marketing copy
- changed similar copy in the footer to the _abbreviated_ version of the slogan