### PR TITLE
Account deletion and support content

### DIFF
--- a/account-deletion.md
+++ b/account-deletion.md
@@ -2,4 +2,4 @@
 layout: raw
 permalink: /static/account-deletion/
 ---
-In order to delete your Gymnasium account, please send us a message by clicking on the orange and white icon on the lower right-hand side of the screen or send an email to **help@thegymnasium.com**, and we'll take care of it.
+## <mark>This is placeholder content</mark>

--- a/account-deletion.md
+++ b/account-deletion.md
@@ -1,0 +1,5 @@
+---
+layout: raw
+permalink: /static/account-deletion/
+---
+In order to delete your Gymnasium account, please send us a message by clicking on the orange and white icon on the lower right-hand side of the screen or send an email to **help@thegymnasium.com**, and we'll take care of it.

--- a/support.html
+++ b/support.html
@@ -8,6 +8,6 @@ permalink: /static/support/
 <p>One thing we hear from our Gymnasium students is that our team responds to their questions so quickly it puts the online education competition to shame. We try to have support available during the times you’re taking the courses, but are not available 24/7. Here are some guidelines to getting help with Gymnasium. </p>
 <ul>
   <li>If your question is related to course material, homework, or your understanding of a concept, check out the forums. There you’ll find other students and teaching assistants eager to share their knowledge.</li>
-  <li>If you have a  question about something other than the course material, click on the question mark located in the lower-right corner of Gymnasium to leave a message with someone on our support team. We’ll answer your question as soon as we can get to it!</li>
+  <li>Have a question about something other than the course material? Click on the orange icon located in the lower right-hand corner of our website to leave a message with our support team. (We typically answer within a few hours.)</li>
   <li>Don’t forget, you can always go “old school” and send an email to <b>help@thegymnasium.com</b>. Sorry, faxes are a little too old school for us.</li>
 </ul>


### PR DESCRIPTION
## What this PR does

1. Adds a placeholder for account deletion content on the account settings page — in the hope that we can change what's there currently 💩 
https://deploy-preview-547--thegymcms.netlify.app/static/account-deletion/

2. Updates the description of the Intercom icon on the support page so that it actually describes the actual Intercom icon 
https://deploy-preview-547--thegymcms.netlify.app/static/support/