### PR TITLE
point to new Open edX logo

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -105,7 +105,7 @@ permalink: /static/footer/
         <div class="col-xs-12">
           <a title="Open edX" href="http://openedx.org" target="_blank" rel="noopener">
             <img class="open-edx-logo" alt="Powered by Open edX" src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png"
-              width="150" height="50" decoding="async">
+              width="175" height="70" decoding="async">
           </a>
           <div class="copyright"><small>© {{ 'now' | date: "%Y" }}  <a href="https://thegymnasium.com">Aquent Gymnasium</a></small></div>
         </div>

--- a/footer.html
+++ b/footer.html
@@ -104,7 +104,7 @@ permalink: /static/footer/
       <div class="row">
         <div class="col-xs-12">
           <a title="Open edX" href="http://openedx.org" target="_blank" rel="noopener">
-            <img class="open-edx-logo" alt="Powered by Open edX" src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png"
+            <img class="open-edx-logo" alt="Powered by Open edX" src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png"
               width="150" height="50" decoding="async">
           </a>
           <div class="copyright"><small>© {{ 'now' | date: "%Y" }}  <a href="https://thegymnasium.com">Aquent Gymnasium</a></small></div>


### PR DESCRIPTION
Open edX updated their logo... our "powered by" auto updated but there is a variant specifically for dark backgrounds that we should use.

https://github.com/edx/edx-platform/wiki/Powered-by-Open-edX-Logos

Note: They specify different dimensions than we're using... @jgagne should we increase to 175x70?