### PR TITLE
make two heros from one data file

### DIFF
--- a/_data/hero.yml
+++ b/_data/hero.yml
@@ -1,0 +1,3 @@
+current_promo: hero-collections.html
+auth_promo: hero-bbd-2020.html
+live_coding: false

--- a/_layouts/hero.html
+++ b/_layouts/hero.html
@@ -1,0 +1,15 @@
+---
+
+---
+{%- assign hero = site.data.hero -%}
+
+{%- if hero.live_coding == true -%}
+<!-- Display live coding on both hero includes -->
+{%- include hero-livecoding.html -%}
+    {%- elsif page.permalink contains "hero-auth" and hero.auth_promo -%}
+        <!-- Display something specific on the authenticated hero include -->
+        {%- include {{hero.auth_promo}} -%} 
+    {%- else -%}
+    <!-- Display the current promo on both hero includes -->
+    {%- include {{hero.current_promo}} -%}
+{%- endif -%}

--- a/home/hero-authenticated.html
+++ b/home/hero-authenticated.html
@@ -1,0 +1,4 @@
+---
+layout: hero
+permalink: /static/home/hero-auth/
+---

--- a/home/hero.html
+++ b/home/hero.html
@@ -1,11 +1,4 @@
 ---
-layout: raw
+layout: hero
 permalink: /static/home/hero/
-live_coding: false
-current_promo: hero-collections.html
 ---
-{% if page.live_coding == true %}
-{% include hero-livecoding.html %}
-{% else %}
-{% include {{page.current_promo}} %}
-{% endif %}


### PR DESCRIPTION
## What this PR purports to do:
- move hero configuration to a (single) YAML data file
- generate two hero includes — one for all users and one for authenticated users

### Assumptions:
- LiveCoding toggle will overide settings for both hero includes
- The `current_promo` is the default for both hero includes
- The logic to include public/authenticated based on the logged-in state will be handled by the homepage template

### Test scenarios:

Public hero: Collections
Authenticated hero: Blue Beanie Day 2020

```yml
current_promo: hero-collections.html
auth_promo: hero-bbd-2020.html
live_coding: false
```
---

Public hero: Collections
Authenticated hero: Collections

```yml
current_promo: hero-collections.html
auth_promo: 
live_coding: false
```
---

Public hero: Live Coding
Authenticated hero: Live Coding

```yml
current_promo: hero-collections.html
auth_promo: 
live_coding: true
```
---

**Public Hero:** `/static/home/hero/`
https://deploy-preview-584--thegymcms.netlify.app/static/home/hero/

**Authenticated Hero:** `/static/home/hero-auth/`
https://deploy-preview-584--thegymcms.netlify.app/static/home/hero-auth/
