### PR TITLE
Adds design systems stub

### DIFF
--- a/_data/collections/col0006-design-systems.yml
+++ b/_data/collections/col0006-design-systems.yml
@@ -1,0 +1,7 @@
+---
+collection_ID: col0006-design-systems
+title: "Design Systems"
+topic: "Design Systems"
+short_description: "Lorem Ipsum: Learn best practices for design systems..."
+url: https://thegymnasium.com/design-systems
+---

--- a/css/design-systems.scss
+++ b/css/design-systems.scss
@@ -7,3 +7,8 @@ TODO: reconcile this with the concurrent work happening here: @https://github.co
 This file will automatically compile as design-systems.css, assuming the front matter block (double ---) exists
 
 */
+.ds {
+  &--about {
+    background-color: green; // example
+  }
+}

--- a/css/design-systems.scss
+++ b/css/design-systems.scss
@@ -1,0 +1,9 @@
+---
+---
+/* 
+
+TODO: reconcile this with the concurrent work happening here: @https://github.com/gymnasium/gymcms/tree/feature/145-enable-sass
+
+This file will automatically compile as design-systems.css, assuming the front matter block (double ---) exists
+
+*/

--- a/hub-pages/design-systems/index.html
+++ b/hub-pages/design-systems/index.html
@@ -1,0 +1,29 @@
+---
+permalink: /static/design-systems/
+layout: raw
+---
+
+{%- if jekyll.environment == "development" -%}
+  {%- include take5/test-top.html -%}
+{%- endif -%}
+
+<link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/design-systems.css">
+
+<main id="main" role="main">
+
+<header class="ds--about" id="about">
+  <div class="container">
+    <h1>Design Systems</h1>
+    <p>Lorem ipsum me...</p>
+  </div>
+</header>
+
+<div class="container">
+  <!-- populate me -->
+</div>
+
+</main>
+
+{%- if jekyll.environment == "development" -%}
+  {%- include take5/test-bottom.html -%}
+{%- endif -%}

--- a/hub-pages/design-systems/meta.md
+++ b/hub-pages/design-systems/meta.md
@@ -2,7 +2,7 @@
 layout: meta
 permalink: /static/hub-pages/design-systems/meta/
 page_title: "Design Systems | Gymnasium"
-og_title: "design-systems"
+og_title: "Design Systems"
 og_description: "Lorem ipsum for design systems..."
 og_art: img/hub-pages/og/design-systems-og.png
 og_url: https://thegymnasium.com/design-systems

--- a/hub-pages/design-systems/meta.md
+++ b/hub-pages/design-systems/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /static/hub-pages/design-systems/meta/
+page_title: "Design Systems | Gymnasium"
+og_title: "design-systems"
+og_description: "Lorem ipsum for design systems..."
+og_art: img/hub-pages/og/design-systems-og.png
+og_url: https://thegymnasium.com/design-systems
+---

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 # staging branch build
 # https://staging.thegymcms.com/
 [context.staging]
-  command = "JEKYLL_ENV=staging bundle exec jekyll build"
+  command = "printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
 # production branch build
 # https://thegymcms.com/
 [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 # staging branch build
 # https://staging.thegymcms.com/
 [context.staging]
-  command = printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml
+  command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
 # production branch build
 # https://thegymcms.com/
 [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 # staging branch build
 # https://staging.thegymcms.com/
 [context.staging]
-  command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
+  command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; echo _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
 # production branch build
 # https://thegymcms.com/
 [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,10 @@
 # staging branch build
 # https://staging.thegymcms.com/
 [context.staging]
-  command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; echo _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
+  command = "JEKYLL_ENV=staging bundle exec jekyll build"
+# Deploy preview build
+[context.deploy-preview]
+  command = "printf \"url: %s\" \"$DEPLOY_PRIME_URL\" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
 # production branch build
 # https://thegymcms.com/
 [context.production]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 # staging branch build
 # https://staging.thegymcms.com/
 [context.staging]
-  command = "printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml"
+  command = printf "url: %s" "$DEPLOY_PRIME_URL" > _config_netlify.yml; JEKYLL_ENV=staging bundle exec jekyll build --config _config.yml,_config_netlify.yml
 # production branch build
 # https://thegymcms.com/
 [context.production]


### PR DESCRIPTION
~~Note: the generated CSS file doesn't exist on staging (yet), which is why we're getting a 404 on that file, which is hard-linked to . Maybe down the road we can figure out how to tell Netlify to use the preview URL for all the static assets served via a PR [maybe via some type of solution as outlined here](https://answers.netlify.com/t/jekyll-site-uses-absolute-urls-deploy-previews-navigate-to-main-site/8441/8).~~

~~The generated CSS file is here and appears to be working properly: https://605b89973381970008005912--thegymcms.netlify.app/css/design-systems.css~~

Deploy preview now uses the preview URL to serve static assets:

* https://deploy-preview-586--thegymcms.netlify.app/static/design-systems/