### PR TITLE
Update courseware final exam style

### DIFF
--- a/system-status.html
+++ b/system-status.html
@@ -208,6 +208,77 @@ main label a:not([class]):active,
 }
 
 /*
+https://github.com/gymnasium/tracker/issues/143
+*/
+
+#main .problems-wrapper {
+  font-size: 16px;
+}
+
+#main .problem-header {
+  font: 900 2.25em "brandon-grotesque", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+#main .problem-progress {
+  font: bold 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  margin-bottom: 5rem;
+}
+
+#main .problem-progress + * + main .message:not([hidden]),
+#main .problem .solution-span > span {
+  margin-top: -2rem;
+  margin-bottom: 5rem;
+}
+
+#main .problem .response-fieldset-legend {
+  font-size: inherit;
+  border-bottom: 0;
+}
+
+#main .choicegroup legend {
+  margin-bottom: 1rem;
+}
+
+#main .problem .response-fieldset-legend img {
+  box-sizing: border-box;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  padding: 1rem;
+  border: 1px solid #999;
+  margin-top: 1.6rem;
+}
+
+#main .problem .choicegroup_correct:before,
+#main .problem .choicetextgroup_correct:before {
+  margin-top: 4px;
+}
+
+#main .problem .choicegroup_incorrect:before,
+#main .problem .choicetextgroup_incorrect:before {
+  margin-top: -3px;
+}
+
+#main .message h2 {
+  text-transform: uppercase;
+}
+
+#main .message p a:not(.btn),
+#main .message  p a:visited:not(.btn) {
+  font: inherit;
+}
+
+/* pre-hawthorn markup patterns */
+
+#main .problem strong + .wrapper-problem-response {
+  margin-top: 1rem;
+}
+
+#main .problem strong + pre {
+  margin-top: 1.6rem;
+}
+
+/*
 https://github.com/gymnasium/tracker/issues/127
 */
 
@@ -223,7 +294,7 @@ https://github.com/gymnasium/tracker/issues/127
 }
 
 #passwordreset-form h2.section-title {
-  font: 900 2.571428571428571em/1 brandon-grotesque, "Helvetica Neue", Helvetica, sans-serif;
+  font: 900 2.571428571428571em/1 "brandon-grotesque", "Helvetica Neue", Helvetica, sans-serif;
   color: #333;
   letter-spacing: 0.01em;
   word-spacing: 0.04em;
@@ -257,7 +328,7 @@ https://github.com/gymnasium/tracker/issues/127
 
 #passwordreset-form .action-primary {
   width: 100%;
-  font: bold 1.5em/1 brandon-grotesque, "Helvetica Neue", Helvetica, sans-serif;
+  font: bold 1.5em/1 "brandon-grotesque", "Helvetica Neue", Helvetica, sans-serif;
   background-color: #f8971d;
   padding: 1em;
   border-radius: .125em;


### PR DESCRIPTION
## What this PR does:

Updates final exam styles for Hawthorn and Pre-Hawthorn markup to improve the overall visual and user experience.

- Updates final exam heading size, weight, and spacing
- Updates final exam grade text size, weight, and spacing
- Updates message heading; set to uppercase for emphasis
- Updates message link; inherit font-family
- Updates problem text size; resolves: https://github.com/gymnasium/tracker/issues/143
- Updates problem explanation spacing
- Updates problem correct and incorrect mark position
- Updates problem image and code spacing

- - -

### Todo

- Remove final exam inline style for images in "Design Systems for Everyone" on staging and production.

### Note

- Thoughts on updating button text "Show Answer" to "Show Answers" later?

- - -

#### Header, Message, & Problem

**Before:**

![gym-final-exam-message](https://user-images.githubusercontent.com/5142085/115725651-0ade8b00-a350-11eb-9083-82c54fd4830d.png)

**After:**

![gym-final-exam-message-update](https://user-images.githubusercontent.com/5142085/115725656-0c0fb800-a350-11eb-8eae-1838067b2dc6.png)

- - -

#### Explanations

**Before:**

![gym-final-exam-explanation](https://user-images.githubusercontent.com/5142085/115725830-2ea1d100-a350-11eb-9299-36939e9125e3.png)

**After:**

![gym-final-exam-explanation-update](https://user-images.githubusercontent.com/5142085/115725821-2cd80d80-a350-11eb-9664-4664cffbb51b.png)

- - -

#### Correct/Incorrect Marks

**Before:**

![gym-final-exam-grade-marks](https://user-images.githubusercontent.com/5142085/115726048-5e50d900-a350-11eb-9050-4bd9bf530b7f.png)

**After:**

![gym-final-exam-grade-marks-update](https://user-images.githubusercontent.com/5142085/115726051-5f820600-a350-11eb-92de-6f6be1637bc1.png)