### PR TITLE
patch/more-meta-fixes

### DIFF
--- a/_layouts/take5-meta.html
+++ b/_layouts/take5-meta.html
@@ -23,22 +23,22 @@
 <!-- Reuse Title or something more descriptive? -->
 <meta name="twitter:image:alt" content="{{ course.title | prepend: 'Video poster for tutorial titled ' }}">
 
-<link rel="apple-touch-icon" sizes="57x57" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="https://gymnasium.github.io/cms/favicon.ico/apple-icon-180x180.png">
-<link rel="icon" type="image/png" sizes="192x192"  href="https://gymnasium.github.io/cms/favicon.ico/android-icon-192x192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://gymnasium.github.io/cms/favicon.ico/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="96x96" href="https://gymnasium.github.io/cms/favicon.ico/favicon-96x96.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://gymnasium.github.io/cms/favicon.ico/favicon-16x16.png">
-<link rel="manifest" href="https://gymnasium.github.io/cms/favicon.ico/manifest.json">
+<link rel="apple-touch-icon" sizes="57x57" href="{{ site.url }}/favicon/apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="{{ site.url }}/favicon/apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="{{ site.url }}/favicon/apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="{{ site.url }}/favicon/apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="{{ site.url }}/favicon/apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="{{ site.url }}/favicon/apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="{{ site.url }}/favicon/apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="{{ site.url }}/favicon/apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}/favicon/apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192"  href="{{ site.url }}/favicon/android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}/favicon/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="{{ site.url }}/favicon/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}/favicon/favicon-16x16.png">
+<link rel="manifest" href="{{ site.url }}/favicon/manifest.json">
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="https://gymnasium.github.io/cms/favicon.ico/ms-icon-144x144.png">
+<meta name="msapplication-TileImage" content="{{ site.url }}/favicon/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">
 
 

--- a/tests/take5/take5-content-test.html
+++ b/tests/take5/take5-content-test.html
@@ -142,7 +142,7 @@ td.success {
     {% capture meta_partial_test %}{% file_exists {{ meta_partial }} %}{% endcapture %}
     {% if meta_partial_test == "false" %}<td class="error">MISSING FILE</td>{% else %}
     <td>
-        <a href="/take5/meta/{{ item.course_ID | append: '-meta/' | downcase }}" target="_blank">{{ meta_partial_test }}</a>
+        <a href="/courses/take5/{{ item.course_ID | append: '/meta/' | downcase }}" target="_blank">{{ meta_partial_test }}</a>
     </td>
     {% endif %}
 

--- a/tests/take5/take5-content-test.html
+++ b/tests/take5/take5-content-test.html
@@ -137,7 +137,8 @@ td.success {
     {% endif %}
 
     <!-- Meta tag partial -->
-    {% assign meta_partial = item.course_ID | prepend: '/take5/meta/' | append: '-meta.md' | downcase %}
+    {% assign meta_partial = item.course_ID | prepend: 'courses/take5/' | append: '/meta.md' %}
+    <!-- *** {{ meta_partial }} -->
     {% capture meta_partial_test %}{% file_exists {{ meta_partial }} %}{% endcapture %}
     {% if meta_partial_test == "false" %}<td class="error">MISSING FILE</td>{% else %}
     <td>


### PR DESCRIPTION
## What this PR does:

- fixes the take 5 [content test](https://deploy-preview-614--thegymcms.netlify.app/tests/take5-content/) to look for the meta partial file in the right place (now).
- updates the take 5 meta layout to point to the favicon stuff on the gymcms (instead of github pages)
- resolves https://github.com/gymnasium/tracker/issues/162

### To verify:

Look at the meta for this take 5 here:
https://deploy-preview-614--thegymcms.netlify.app/courses/take5/gym-5001/meta/

And compare to the same on staging:
https://staging.thegymcms.com/courses/take5/gym-5001/meta/