### PR TITLE
Prevent a redirection error when auto-testing links

### DIFF
--- a/_data/take5/GYM-5015.yml
+++ b/_data/take5/GYM-5015.yml
@@ -18,7 +18,7 @@ project_files:
   url: "https://gymnasium.github.io/take5/gym-5015.zip"
 related_content:
 - label: "Official Figma documentation for Smart Animate"
-  url: "https://help.figma.com/article/365-smart-animate"
+  url: "https://help.figma.com/hc/en-us/articles/360039818874"
 - label: "Figma Tutorial: Smart Animate and Drag Triggers"
   url: "https://www.youtube.com/watch?v=6Id4INKEwb8"
 - label: "iOS Animations with Figma’s Smart Animations by Lucas Chae"


### PR DESCRIPTION
Figma has updated their URL scheme, evidently.