### PR TITLE
[Feature] Add disclaimer to account deletion text

### DIFF
--- a/js/gymnasium.js
+++ b/js/gymnasium.js
@@ -193,7 +193,7 @@ class Gymnasium {
       location: cityId,
       utm_campaign: "Registration",
       carrot_type: "Gymnasium Registration",
-      carrot_topic: "GYM REG",
+      carrot_topic: "GYM REG", // How Heard Other in CW
       PROC: "AWUISubmitExternalLead",
     };
 

--- a/partials/account-deletion.html
+++ b/partials/account-deletion.html
@@ -4,6 +4,7 @@ permalink: /partials/account-deletion/
 ---
 <div id="deletion-helper" class="hide" style="display: none;">
   <p>To delete your data, please fill out <a href="https://privacyportal.onetrust.com/webform/05f24bb5-a0c4-43d4-966e-05606d5be9ca/93b6b82e-baf8-4adc-8998-0df20831be6d" rel="noopener" target="_blank">our data deletion request form</a>.</p>
+  <p>Be advised that deleting your data will remove your Accredible certificates earned through us. Please back up your certificates if you plan on keeping them.</p>
 </div>
 <script>
   window.addEventListener('load', (event) => {

--- a/partials/account-deletion.html
+++ b/partials/account-deletion.html
@@ -4,7 +4,7 @@ permalink: /partials/account-deletion/
 ---
 <div id="deletion-helper" class="hide" style="display: none;">
   <p>To delete your data, please fill out <a href="https://privacyportal.onetrust.com/webform/05f24bb5-a0c4-43d4-966e-05606d5be9ca/93b6b82e-baf8-4adc-8998-0df20831be6d" rel="noopener" target="_blank">our data deletion request form</a>.</p>
-  <p>Be advised that deleting your data will remove any Accredible certificates or badges that you have earned on the Gymnasium. Please back up your certificates or badges immediately if you plan on keeping them.</p>
+  <p>Be advised that deleting your data will remove any certificates/badges that you have earned on the Gymnasium. Please back up (or download) your certificates/badges immediately if you plan on keeping them.</p>
 </div>
 <script>
   window.addEventListener('load', (event) => {

--- a/partials/account-deletion.html
+++ b/partials/account-deletion.html
@@ -4,7 +4,7 @@ permalink: /partials/account-deletion/
 ---
 <div id="deletion-helper" class="hide" style="display: none;">
   <p>To delete your data, please fill out <a href="https://privacyportal.onetrust.com/webform/05f24bb5-a0c4-43d4-966e-05606d5be9ca/93b6b82e-baf8-4adc-8998-0df20831be6d" rel="noopener" target="_blank">our data deletion request form</a>.</p>
-  <p>Be advised that deleting your data will remove your Accredible certificates earned through us. Please back up your certificates if you plan on keeping them.</p>
+  <p>Be advised that deleting your data will remove any Accredible certificates or badges that you have earned on the Gymnasium. Please back up your certificates or badges immediately if you plan on keeping them.</p>
 </div>
 <script>
   window.addEventListener('load', (event) => {


### PR DESCRIPTION
This paltry legalese is to remind users to download their certificates when deleting their account data.

See https://github.com/gymnasium/tracker/issues/185