### PR TITLE
[Feature]: Creates new 404 HTML page, updates copy, adds email obfuscation plugin

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,9 +1,0 @@
----
-title: "404: File Not Found"
-layout: default
-permalink: /404.html
----
-
-# 404 - Not Found
-
-### ...or maybe it never even existed in the first place...?

--- a/_plugins/obfuscate_email.rb
+++ b/_plugins/obfuscate_email.rb
@@ -1,0 +1,51 @@
+# This does some quick HTML encoding on email addresses to make them
+# slightly harder to find for spam bots.  The idea and implementation
+# are both copied directly from Markdown.pl.
+
+module Jekyll
+  module EmailObfuscationFilter
+
+    # Based on similar obfuscation code from Markdown.pl 1.0.1, the original
+    # Markdown implementation, L1190-1239.
+    # See https://daringfireball.net/projects/markdown/
+    def encode_email_char(char)
+      encoded_chars = [
+        "&#"  + char.ord.to_s     + ";",
+        "&#x" + char.ord.to_s(16) + ";",
+                char,
+      ]
+
+      # This must be encoded
+      if char == "@"
+        encoded_chars[0..1].sample
+      else
+        r = rand()
+        if r > 0.9
+          encoded_chars[2]
+        elsif r < 0.45
+          encoded_chars[1]
+        else
+          encoded_chars[0]
+        end
+      end
+    end
+
+    def encode_email(addr)
+      addr
+        .chars.map { |char| encode_email_char(char) }
+        .join("")
+    end
+
+    def encode_mailto(addr)
+      encode_email("mailto:#{addr}")
+    end
+
+    def create_mailto_link(addr)
+      mailto_addr = encode_email("mailto:#{addr}")
+      email_addr = encode_email(addr)
+      "<a href=\"#{mailto_addr}\">#{email_addr}</a>"
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::EmailObfuscationFilter)

--- a/static-pages/404/index.html
+++ b/static-pages/404/index.html
@@ -24,6 +24,6 @@ permalink: /404/
     <li><a href="/courses#take5">Tutorials</a></li>
   </ul>
 
-  <p>Need to get in touch? You can email us at <strong><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></strong>.</p>
+  <p>Need to get in touch? You can email us at <strong><a href="{{ 'mailto:help@thegymnasium.com?subject=Get+In+Touch' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></strong>.</p>
 
 </div><!-- .main-content-static -->

--- a/static-pages/404/index.html
+++ b/static-pages/404/index.html
@@ -1,0 +1,29 @@
+---
+layout: wrapper-full-white
+permalink: /404/
+---
+{%- if site.environment == 'local' -%}
+<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
+{%- endif -%}
+
+<!-- Temporary HTML for style hooks -->
+<div class="main-content-static">
+
+  <h1>404 - Page Not Found</h1>
+
+  <p class="hero-text">👋 You discovered a page that doesn’t exist.</p>
+
+  <p>Some might call you lost. Others might call you a creative genius. </p>
+
+  <p>Either way, we suggest that you check out our frequently visited pages below:</p>
+
+  <ul>
+    <li><a href="/">Homepage</a></li>
+    <li><a href="/courses#full">Full Courses</a></li>
+    <li><a href="/courses#gymshorts">Gym Shorts</a></li>
+    <li><a href="/courses#take5">Tutorials</a></li>
+  </ul>
+
+  <p>Need to get in touch? You can email us at <strong><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></strong>.</p>
+
+</div><!-- .main-content-static -->

--- a/static-pages/404/meta.md
+++ b/static-pages/404/meta.md
@@ -1,0 +1,12 @@
+---
+layout: meta
+permalink: /404/meta/
+page_title: "Aquent Gymnasium"
+catalog: false
+og_title: "Aquent Gymnasium"
+og_description: "Gymnasium offers free online courses on web development, design, user experience, and content creation."
+og_keywords: "free online courses designers design user experience UX javascript node nodejs sketch wordpress drupal UI"
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/
+css: [/css/static-main-content.css]
+---

--- a/static-pages/about/index.html
+++ b/static-pages/about/index.html
@@ -2,12 +2,12 @@
 layout: wrapper-75-25
 permalink: /about/
 ---
+{%- if site.environment == 'local' -%}
+<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
+{%- endif -%}
 
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
-  {%- if site.environment == 'local' -%}
-    <link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-  {%- endif -%}
 
   <h1>About</h1>
 
@@ -33,4 +33,6 @@ permalink: /about/
     </div>
   </div>
 
-</div><!-- / Temporary HTML for style hooks -->
+</div><!-- .main-content-static -->
+
+<!-- / Temporary HTML for style hooks -->

--- a/static-pages/faq/index.html
+++ b/static-pages/faq/index.html
@@ -87,12 +87,12 @@ permalink: /faq/
 
   <li>
     <h2>How Can I Delete My Account?</h2>
-    <p>We understand, but we do hate to see you go. Send an email to <b>help@thegymnasium.com</b> and we’ll take care of everything for you.</p>
+    <p>We understand, but we do hate to see you go. Send an email to <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b> and we’ll take care of everything for you.</p>
   </li>
 
   <li>
     <h2>Where Can I Get Help If I Hit A Snag?</h2>
-    <p>It depends on the snag. For anything course-related, you should post to the Forum, where fellow students and course TAs can provide help. For non-course related questions (technical or otherwise), click on the Intercom icon on the lower right side of the screen or email <b><b>help@thegymnasium.com</b></b>. We are usually able to respond to all questions within a few hours.</p>
+    <p>It depends on the snag. For anything course-related, you should post to the Forum, where fellow students and course TAs can provide help. For non-course related questions (technical or otherwise), click on the Intercom icon on the lower right side of the screen or email <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. We are usually able to respond to all questions within a few hours.</p>
   </li>
 
   <li>

--- a/static-pages/faq/index.html
+++ b/static-pages/faq/index.html
@@ -87,12 +87,12 @@ permalink: /faq/
 
   <li>
     <h2>How Can I Delete My Account?</h2>
-    <p>We understand, but we do hate to see you go. Send an email to <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b> and we’ll take care of everything for you.</p>
+    <p>We understand, but we do hate to see you go. Send an email to <b><a href="{{ 'mailto:help@thegymnasium.com?subject=Get+In+Touch' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b> and we’ll take care of everything for you.</p>
   </li>
 
   <li>
     <h2>Where Can I Get Help If I Hit A Snag?</h2>
-    <p>It depends on the snag. For anything course-related, you should post to the Forum, where fellow students and course TAs can provide help. For non-course related questions (technical or otherwise), click on the Intercom icon on the lower right side of the screen or email <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. We are usually able to respond to all questions within a few hours.</p>
+    <p>It depends on the snag. For anything course-related, you should post to the Forum, where fellow students and course TAs can provide help. For non-course related questions (technical or otherwise), click on the Intercom icon on the lower right side of the screen or email <b><a href="{{ 'mailto:help@thegymnasium.com?subject=Get+In+Touch' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. We are usually able to respond to all questions within a few hours.</p>
   </li>
 
   <li>

--- a/static-pages/support/index.html
+++ b/static-pages/support/index.html
@@ -9,5 +9,5 @@ permalink: /support/
 <ul>
   <li>If your question is related to course material, homework, or your understanding of a concept, check out the forums. There you’ll find other students and teaching assistants eager to share their knowledge.</li>
   <li>Have a question about something other than the course material? Click on the orange icon located in the lower right-hand corner of our website to leave a message with our support team. (We typically answer within a few hours.)</li>
-  <li>Don’t forget, you can always go “old school” and send an email to <b>help@thegymnasium.com</b>. Sorry, faxes are a little too old school for us.</li>
+  <li>Don’t forget, you can always go “old school” and send an email to <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. Sorry, faxes are a little too old school for us.</li>
 </ul>

--- a/static-pages/support/index.html
+++ b/static-pages/support/index.html
@@ -9,5 +9,5 @@ permalink: /support/
 <ul>
   <li>If your question is related to course material, homework, or your understanding of a concept, check out the forums. There you’ll find other students and teaching assistants eager to share their knowledge.</li>
   <li>Have a question about something other than the course material? Click on the orange icon located in the lower right-hand corner of our website to leave a message with our support team. (We typically answer within a few hours.)</li>
-  <li>Don’t forget, you can always go “old school” and send an email to <b><a href="{{ 'mailto:help@thegymnasium.com' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. Sorry, faxes are a little too old school for us.</li>
+  <li>Don’t forget, you can always go “old school” and send an email to <b><a href="{{ 'mailto:help@thegymnasium.com?subject=Get+In+Touch' | encode_email }}">{{ 'help@thegymnasium.com' | encode_email }}</a></b>. Sorry, faxes are a little too old school for us.</li>
 </ul>


### PR DESCRIPTION
What this PR does:
- updates the 404 page copy per https://docs.google.com/document/d/1394_Rfr1hZmZg9OW_plW6XdepyTcN-FXDYT5wLDn4OM/edit
- updates the 404 page layout
- adds an email obfuscation filter (see @https://alexwlchan.net/2019/06/a-jekyll-filter-for-obfuscating-email-addresses/ and @https://github.com/alexwlchan/alexwlchan.net/tree/live/src/_plugins)


Preview:
* https://deploy-preview-674--thegymcms.netlify.app/404/

FYI the 404 page will be pulling in the CSS file via the meta module. Ergo, this can be tweaked more once these changes are on staging.