### PR TITLE
Update retired course message

### DIFF
--- a/_data/courses/GYM-100.yml
+++ b/_data/courses/GYM-100.yml
@@ -4,7 +4,9 @@ title: "Coding for Designers"
 date: 2019-10-28T00:00:00-04:00
 course_type: full
 live: true
-retired_message: "This course is retiring on March 25, 2022.<br> Enrollment ends on January 31, 2022."
+retired_message:
+  1: "This course is retiring on March 25, 2022.<br> Enrollment ends on January 31, 2022."
+  2: "This course is retiring and all coursework needs be completed by March 25, 2022."
 url: /courses/GYM/100/0/about
 poster_art: /img/course-artwork/png/gym-100.png
 topic: "Web Design & Development"
@@ -20,5 +22,4 @@ audience:
   - label: "Creatives"
   - label: "Copy Editors"
   - label: "Anyone struggling with HTML"
-
 ---

--- a/css/main.scss
+++ b/css/main.scss
@@ -2262,35 +2262,45 @@ TODO: migrate discussion CSS out of theme
   margin-bottom: 1em;
 }
 
-.retired-message[data-course-id="100"] .course-description p:before {
-  content: "{{ site.data.courses.GYM-100.retired_message | replace: '<br>', '\a' }}";
-}
+// Info/Courseware pages
 
-// Courseware pages
+[src*="gym-100"][hidden] + *:before {
+  content: "{{ site.data.courses.GYM-100.retired_message[2] }}";
+}
 
 [src*="gym-100"] + *:before,
 [src*="gym-100"][hidden] + *:before {
   position: relative;
-  content: "{{ site.data.courses.GYM-100.retired_message | replace: '<br>', '' }}";
   font-size: 1.3225em;;
   padding: 2rem;
   border-top: 0;
   margin: 0;
 }
 
-// About page
-
 [src*="gym-100"]:not([hidden]) {
   margin-top: 5em;
 }
 
-.retired-message [src*="gym-100"] {
-  margin-top: 0
+// Catalog/About page
+
+.retired-message[data-course-id="100"] .course-description p:before {
+  content: "{{ site.data.courses.GYM-100.retired_message[1] | replace: '<br>', '\a' }}";
 }
+
+// About page
 
 [src*="gym-100"] + *:before {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
+  content: "{{ site.data.courses.GYM-100.retired_message[1] | remove: '<br>' }}";
 }
+
+// Catalog page
+
+.retired-message [src*="gym-100"] {
+  margin-top: 0
+}
+
+// and all coursework needs be completed by March 25, 2022."

--- a/css/main.scss
+++ b/css/main.scss
@@ -2294,7 +2294,7 @@ TODO: migrate discussion CSS out of theme
   top: 0;
   left: 0;
   width: 100%;
-  content: "{{ site.data.courses.GYM-100.retired_message[1] | remove: '<br>' }}";
+  content: "{{ site.data.courses.GYM-100.retired_message[1] | remove: '<br>' }}" !important;
 }
 
 // Catalog page


### PR DESCRIPTION
## What this PR does

- Updates retired message based on course page
  - Catalog and About:
    -  This course is retiring on March 25, 2022. Enrollment ends on January 31, 2022. 
  - Info/Syllabus and Courseware/Lessons:
    - This course is retiring and all coursework needs be completed by March 25, 2022.