### PR TITLE
[Bug fix]: Add missing take 5 og:title/page title data

### DIFF
--- a/_includes/partials/meta/logic-take5.html
+++ b/_includes/partials/meta/logic-take5.html
@@ -5,6 +5,6 @@ Set up meta tags for a Take 5 meta include
 {%- assign og_description = course.short_description -%}
 {%- assign og_title = course.title -%}
 {%- assign og_url = course.title | slugify | prepend: "/courses/take5/" -%}
-{%- assign page_title = "Take 5 | Gymnasium" -%}
+{%- assign page_title =  course.title | append: " | Gymnasium" -%}
 {%- assign og_art = course.course_ID | downcase | append: "-og.png" | prepend: "/img/take5/og/" -%}
 {%- assign og_img_alt = course.title | prepend: "Video poster for tutorial titled " -%}

--- a/_includes/partials/meta/logic-take5.html
+++ b/_includes/partials/meta/logic-take5.html
@@ -3,6 +3,7 @@ Set up meta tags for a Take 5 meta include
 {%- endcomment -%}
 {%- assign course = site.data.take5[id] -%}
 {%- assign og_description = course.short_description -%}
+{%- assign og_title = course.title -%}
 {%- assign og_url = course.title | slugify | prepend: "/courses/take5/" -%}
 {%- assign page_title = "Take 5 | Gymnasium" -%}
 {%- assign og_art = course.course_ID | downcase | append: "-og.png" | prepend: "/img/take5/og/" -%}


### PR DESCRIPTION
For some reason, we all completely missed this, despite having this tool to check our metas: https://thegymcms.com/tests/catalog/metas

Note that all the 5000 level items have the page title/og:title data from the 700 course.

Unfortunately, the tool does nothing to highlight missing metas - it just dumbly spits out whatever is available.

Compare to the fixed version: https://deploy-preview-834--thegymcms.netlify.app/tests/catalog/metas

Resolves bug: https://github.com/gymnasium/tracker/issues/310