### PR TITLE
[Feature]: Adds holiday card stubs

### DIFF
--- a/holiday-card/2020/index.html
+++ b/holiday-card/2020/index.html
@@ -1,0 +1,9 @@
+---
+layout: wrapper-full-white
+permalink: /holiday-card/2020/
+---
+<header>
+  <h1>2020 Holiday Card</h1>
+  <p>Season's greetings from Aquent Gymnasium.</p>
+</header>
+

--- a/holiday-card/2020/meta.md
+++ b/holiday-card/2020/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /holiday-card/2020/meta/
+page_title: "2020 Holiday Card | Gymnasium"
+og_title: "2020 Holiday Card"
+og_description: "Season's greetings from Aquent Gymnasium."
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/holiday-card/2020
+---

--- a/holiday-card/2021/index.html
+++ b/holiday-card/2021/index.html
@@ -1,0 +1,9 @@
+---
+layout: wrapper-full-white
+permalink: /holiday-card/2021/
+---
+<header>
+  <h1>2021 Holiday Card</h1>
+  <p>Season's greetings from Aquent Gymnasium.</p>
+</header>
+

--- a/holiday-card/2021/meta.md
+++ b/holiday-card/2021/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /holiday-card/2021/meta/
+page_title: "2021 Holiday Card | Gymnasium"
+og_title: "2021 Holiday Card"
+og_description: "Season's greetings from Aquent Gymnasium."
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/holiday-card/2021
+---

--- a/holiday-card/2022/index.html
+++ b/holiday-card/2022/index.html
@@ -1,0 +1,9 @@
+---
+layout: wrapper-full-white
+permalink: /holiday-card/2022/
+---
+<header>
+  <h1>2022 Holiday Card</h1>
+  <p>Season's greetings from Aquent Gymnasium.</p>
+</header>
+

--- a/holiday-card/2022/meta.md
+++ b/holiday-card/2022/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /holiday-card/2022/meta/
+page_title: "2022 Holiday Card | Gymnasium"
+og_title: "2022 Holiday Card"
+og_description: "Season's greetings from Aquent Gymnasium."
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/holiday-card/2022
+---

--- a/holiday-card/happy-new-year/index.html
+++ b/holiday-card/happy-new-year/index.html
@@ -1,0 +1,9 @@
+---
+layout: wrapper-full-white
+permalink: /happy-new-year/
+---
+<header>
+  <h1>Happy New Year</h1>
+  <p>Season's greetings from Aquent Gymnasium.</p>
+</header>
+

--- a/holiday-card/happy-new-year/meta.md
+++ b/holiday-card/happy-new-year/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /happy-new-year/meta/
+page_title: "Happy New Year | Gymnasium"
+og_title: "Happy New Year"
+og_description: "Season's greetings from Aquent Gymnasium."
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com//happy-new-year
+---

--- a/holiday-card/index.html
+++ b/holiday-card/index.html
@@ -9,4 +9,5 @@ permalink: /holiday-card/
 <ul>
   <li><a href="2022">2022</a></li>
   <li><a href="2021">2021</a></li>
+  <li><a href="2020">2020</a></li>
 </ul>

--- a/holiday-card/index.html
+++ b/holiday-card/index.html
@@ -1,0 +1,12 @@
+---
+layout: wrapper-full-white
+permalink: /holiday-card/
+---
+<header>
+  <h1>Holiday Cards</h1>
+  <p>Season's greetings from Aquent Gymnasium.</p>
+</header>
+<ul>
+  <li><a href="2022">2022</a></li>
+  <li><a href="2021">2021</a></li>
+</ul>

--- a/holiday-card/meta.md
+++ b/holiday-card/meta.md
@@ -1,0 +1,9 @@
+---
+layout: meta
+permalink: /holiday-card/meta/
+page_title: "Holiday Cards | Gymnasium"
+og_title: "Holiday Cards"
+og_description: "Season's greetings from Aquent Gymnasium."
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/holiday-card
+---


### PR DESCRIPTION
Adding the following paths to gymcms/theme:
- `/happy-new-year`
- `/holiday-card`
- `/holiday-card/2022`
- `/holiday-card/2021`
- `/holiday-card/2020`

These are currently not linked to or referenced anywhere, so we should be OK deploying them at will.


See https://github.com/gymnasium/tracker/issues/315