### PR TITLE
[Feature]: Recreate 2021/2020 cards with HTML/CSS

### DIFF
--- a/_includes/partials/meta/tags.html
+++ b/_includes/partials/meta/tags.html
@@ -64,16 +64,11 @@ https://stackoverflow.com/questions/50824181/preloading-google-fonts
 <link rel="stylesheet" href="{{ site.url }}/css/fonts/font-awesome.css?{{ site.time | date:'%s' }}">
 <link rel="stylesheet" href="{{ site.url }}/css/main.css?{{ site.time | date:'%s' }}">
 
-{% comment -%}
-Exclude rendered CSS in meta tags on localhost, for development/convenience reasons
-{%- endcomment -%}
-{%- unless site.environment == 'local' -%}
-  {%- if page.css -%}
-    {%- for css_file in page.css -%}
-      <link rel="stylesheet" href="{{ site.url }}{{ css_file }}?{{ site.time | date:'%s' }}">
-    {%- endfor -%}
-  {%- endif -%}
-{%- endunless -%}
+{%- if page.css -%}
+  {%- for css_file in page.css -%}
+    <link rel="stylesheet" href="{{ site.url }}{{ css_file }}?{{ site.time | date:'%s' }}">
+  {%- endfor -%}
+{%- endif -%}
 
 {%- comment -%}
 We used to prefetch these, but we really shouldn't bother with 3rd party tracking stuff, since it can potentially slow down our site...

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -395,7 +395,7 @@ To use, `@include holiday-cards;`, then write appropriate overrides.
 */
 @mixin holiday-cards($font-size: 4rem) {
   pre.gym-custom-css {
-    padding: 2rem;
+    padding: 2rem 8rem;
     margin: 4rem 0;
   }
   code.gym-custom-css {

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -435,7 +435,7 @@ To use, `@include holiday-cards;`, then write appropriate overrides.
     &.comment, &.prolog, &.doctype, &.cdata {
       color: $gym-mid-gray;
     }
-    &.selector, &.attr-name, &.string, &.char, &.builtin, &.inserted {
+    &.selector, &.attr-name, &.char, &.builtin, &.inserted {
       color: $holiday-red;
     }
     &.punctuation {

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -395,8 +395,13 @@ To use, `@include holiday-cards;`, then write appropriate overrides.
 */
 @mixin holiday-cards($font-size: 4rem) {
   pre.gym-custom-css {
-    padding: 2rem 8rem;
+    padding: 2rem 4rem;
     margin: 4rem 0;
+
+    @include breakpoint(medium, min) {
+      padding-left: 8rem;
+      padding-right: 8rem;
+    }
   }
   code.gym-custom-css {
     padding: 0;

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -389,3 +389,63 @@
   }
 }
 
+/* HOLIDAY CARD STYLES
+This emulates prismjs using our own custom class name.
+To use, `@include holiday-cards;`, then write appropriate overrides.
+*/
+@mixin holiday-cards($font-size: 4rem) {
+  pre.gym-custom-css {
+    padding: 2rem;
+    margin: 4rem 0;
+  }
+  code.gym-custom-css {
+    padding: 0;
+  }
+  code.gym-custom-css, pre.gym-custom-css {
+    background-color: $gym-black;
+    color: $gym-white;
+    text-shadow: none;
+    font-size: 4rem;// fallback for older browsers
+    font-size: $font-size;
+    font-family: Consolas, Monaco, "Andale Mono", monospace;
+    direction: ltr;
+    text-align: left;
+    // white-space: pre;
+    word-spacing: normal;
+    word-break: break-word;
+    line-height: 1.5;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+  }
+
+  .token {
+    &.tag {
+      color: $holiday-green;
+    }
+    &.comment, &.prolog, &.doctype, &.cdata {
+      color: $gym-mid-gray;
+    }
+    &.selector, &.attr-name, &.string, &.char, &.builtin, &.inserted {
+      color: $holiday-red;
+    }
+    &.punctuation {
+      color: $gym-white;
+    }
+    &.property, &.boolean, &.number, &.constant, &.symbol, &.deleted {
+      color: $gym-light-gray;
+    }
+    &.operator, &.entity, &.url, &.string {
+      color: $gym-white;
+      background: transparent;
+    }
+  }
+
+  .card-content {
+    font-size: 3rem;
+  }
+}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -34,6 +34,9 @@ $gym-teal: #5ca5a0;
 $gym-teal-dark: adjust-color($gym-teal, $lightness: -11.58%); // outputs #46807c
 $gym-teal-darker: adjust-color($gym-teal, $lightness: -26.9%); // #2b4d4b
 
+$holiday-red: #f30d21;
+$holiday-green: #00b600;
+
 // Fonts
 $gym-text-font-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $gym-font-stack: "brandon-grotesque", $gym-text-font-stack;

--- a/css/holiday-card/2020.scss
+++ b/css/holiday-card/2020.scss
@@ -3,3 +3,5 @@
 @import "functions";
 @import "mixins";
 @import "variables";
+
+@include holiday-cards($font-size: calc(5 * (0.5vw + 0.5vh)));

--- a/css/holiday-card/2020.scss
+++ b/css/holiday-card/2020.scss
@@ -4,4 +4,4 @@
 @import "mixins";
 @import "variables";
 
-@include holiday-cards($font-size: calc(5 * (0.5vw + 0.5vh)));
+@include holiday-cards($font-size: calc(4 * (0.5vw + 0.5vh)));

--- a/css/holiday-card/2020.scss
+++ b/css/holiday-card/2020.scss
@@ -1,0 +1,5 @@
+---
+---
+@import "functions";
+@import "mixins";
+@import "variables";

--- a/css/holiday-card/2020.scss
+++ b/css/holiday-card/2020.scss
@@ -4,4 +4,4 @@
 @import "mixins";
 @import "variables";
 
-@include holiday-cards($font-size: calc(4 * (0.5vw + 0.5vh)));
+@include holiday-cards($font-size: calc(2.75 * (1vw + 0.5vh)));

--- a/css/holiday-card/2021.scss
+++ b/css/holiday-card/2021.scss
@@ -4,9 +4,4 @@
 @import "mixins";
 @import "variables";
 
-
-
 @include holiday-cards($font-size: calc(2.5 * (0.5vw + 0.5vh)));
-
-
-

--- a/css/holiday-card/2021.scss
+++ b/css/holiday-card/2021.scss
@@ -4,58 +4,9 @@
 @import "mixins";
 @import "variables";
 
-// This emulates prismjs using our own custom class name
-pre.gym-custom-css {
-  padding: 2rem;
-  margin: 4rem 0;
-}
-code.gym-custom-css {
-  padding: 0;
-}
-code.gym-custom-css, pre.gym-custom-css {
-  background-color: $gym-black;
-  color: $gym-white;
-  text-shadow: none;
-  font-size: 4rem;
-  font-size: calc(2.5 * (0.5vw + 0.5vh));
-  font-family: Consolas, Monaco, "Andale Mono", monospace;
-  direction: ltr;
-  text-align: left;
-  // white-space: pre;
-  word-spacing: normal;
-  word-break: break-word;
-  line-height: 1.5;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
 
-.token {
-  &.style {
-    color: $gym-green;
-  }
-  &.comment, &.prolog, &.doctype, &.cdata {
-    color: $gym-mid-gray;
-  }
-  &.selector, &.attr-name, &.string, &.char, &.builtin, &.inserted {
-    color: $gym-magenta;
-  }
-  &.punctuation {
-    color: $gym-white;
-  }
-  &.property, &.tag, &.boolean, &.number, &.constant, &.symbol, &.deleted {
-    color: $gym-light-gray;
-  }
-  &.operator, &.entity, &.url, &.string {
-    color: $gym-white;
-    background: transparent;
-  }
-}
 
-.card-content {
-  font-size: 3rem;
-}
+@include holiday-cards($font-size: calc(2.5 * (0.5vw + 0.5vh)));
+
+
+

--- a/css/holiday-card/2021.scss
+++ b/css/holiday-card/2021.scss
@@ -1,0 +1,50 @@
+---
+---
+@import "functions";
+@import "mixins";
+@import "variables";
+
+// This emulates prismjs using our own custom class name
+
+code[class*="gym-custom-"], pre[class*="gym-custom-"] {
+  background-color: $gym-black;
+  color: $gym-white;
+  text-shadow: none;
+  font-size: 4rem;
+  font-family: Consolas, Monaco, "Andale Mono", monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+.token {
+  &.style {
+    color: $gym-green;
+  }
+  &.comment, &.prolog, &.doctype, &.cdata {
+    color: $gym-mid-gray;
+  }
+  &.selector, &.attr-name, &.string, &.char, &.builtin, &.inserted {
+    color: $gym-magenta;
+  }
+  &.punctuation {
+    color: $gym-white;
+  }
+  &.property, &.tag, &.boolean, &.number, &.constant, &.symbol, &.deleted {
+    color: $gym-light-gray;
+  }
+  &.operator, &.entity, &.url, &.string {
+    color: $gym-white;
+    background: transparent;
+  }
+}

--- a/css/holiday-card/2021.scss
+++ b/css/holiday-card/2021.scss
@@ -4,4 +4,4 @@
 @import "mixins";
 @import "variables";
 
-@include holiday-cards($font-size: calc(2.5 * (0.5vw + 0.5vh)));
+@include holiday-cards($font-size: calc(1.75 * (1vw + 0.5vh)));

--- a/css/holiday-card/2021.scss
+++ b/css/holiday-card/2021.scss
@@ -5,18 +5,25 @@
 @import "variables";
 
 // This emulates prismjs using our own custom class name
-
-code[class*="gym-custom-"], pre[class*="gym-custom-"] {
+pre.gym-custom-css {
+  padding: 2rem;
+  margin: 4rem 0;
+}
+code.gym-custom-css {
+  padding: 0;
+}
+code.gym-custom-css, pre.gym-custom-css {
   background-color: $gym-black;
   color: $gym-white;
   text-shadow: none;
   font-size: 4rem;
+  font-size: calc(2.5 * (0.5vw + 0.5vh));
   font-family: Consolas, Monaco, "Andale Mono", monospace;
   direction: ltr;
   text-align: left;
-  white-space: pre;
+  // white-space: pre;
   word-spacing: normal;
-  word-break: normal;
+  word-break: break-word;
   line-height: 1.5;
   -moz-tab-size: 4;
   -o-tab-size: 4;
@@ -47,4 +54,8 @@ code[class*="gym-custom-"], pre[class*="gym-custom-"] {
     color: $gym-white;
     background: transparent;
   }
+}
+
+.card-content {
+  font-size: 3rem;
 }

--- a/css/holiday-card/2022.scss
+++ b/css/holiday-card/2022.scss
@@ -1,0 +1,5 @@
+---
+---
+@import "functions";
+@import "mixins";
+@import "variables";

--- a/holiday-card/2020/index.html
+++ b/holiday-card/2020/index.html
@@ -10,7 +10,7 @@ css: [/css/holiday-card/2020.css]
 <section>
 <pre class="gym-custom-css">
 <code class="gym-custom-css">
-<span class="token tag">&lt;img</span> <span class="token attr-name">alt=</span>"Wishing you a happy and healthy holiday season." <span class="token attr-name">src=</span>"gymnasium.gif"<span class="token tag">&gt;</span>
+<span class="token tag">&lt;img</span> <span class="token attr-name">alt=</span><span class="token punctuation">"</span><span class="token string">Wishing you a happy and healthy holiday season.</span><span class="token punctuation">"</span> <span class="token attr-name">src=</span><span class="token punctuation">"</span><span class="token string">gymnasium.gif</span><span class="token punctuation">"</span><span class="token tag">&gt;</span>
 </code>
 </pre>
 </section>

--- a/holiday-card/2020/index.html
+++ b/holiday-card/2020/index.html
@@ -15,11 +15,10 @@ css: [/css/holiday-card/2020.css]
 </pre>
 </section>
 
-<!-- <section class="card-content">
+<section class="card-content">
   <p>Hi there!</p>
-  <p>We wanted to take a moment to say thank you for being a part of our community.</p>
-  <p>Wishing you a happy and healthy new year.</p>
-  <p>Let's learn something new in 2021!</p>
+  <p>As we approach 2021, we wanted to take a moment to thank you for being a friend (cue the music).</p>
+  <p>We appreciate you and the work that you do. Wishing you a happy and healthy holiday season.</p>
+  <p>Until next year!</p>
   <p>&mdash; The Gymnasium Team</p>
-</section> -->
-
+</section>

--- a/holiday-card/2020/index.html
+++ b/holiday-card/2020/index.html
@@ -5,6 +5,21 @@ css: [/css/holiday-card/2020.css]
 ---
 <header>
   <h1>2020 Holiday Card</h1>
-  <p>Season's greetings from Aquent Gymnasium.</p>
 </header>
+
+<section>
+<pre class="gym-custom-css">
+<code class="gym-custom-css">
+<span class="token tag">&lt;img</span> <span class="token attr-name">alt=</span>"Wishing you a happy and healthy holiday season." <span class="token attr-name">src=</span>"gymnasium.gif"<span class="token tag">&gt;</span>
+</code>
+</pre>
+</section>
+
+<!-- <section class="card-content">
+  <p>Hi there!</p>
+  <p>We wanted to take a moment to say thank you for being a part of our community.</p>
+  <p>Wishing you a happy and healthy new year.</p>
+  <p>Let's learn something new in 2021!</p>
+  <p>&mdash; The Gymnasium Team</p>
+</section> -->
 

--- a/holiday-card/2020/index.html
+++ b/holiday-card/2020/index.html
@@ -1,6 +1,7 @@
 ---
 layout: wrapper-full-white
 permalink: /holiday-card/2020/
+css: [/css/holiday-card/2020.css]
 ---
 <header>
   <h1>2020 Holiday Card</h1>

--- a/holiday-card/2020/meta.md
+++ b/holiday-card/2020/meta.md
@@ -6,4 +6,5 @@ og_title: "2020 Holiday Card"
 og_description: "Season's greetings from Aquent Gymnasium."
 og_art: /img/brand/og/gym-brand-og.png
 og_url: https://thegymnasium.com/holiday-card/2020
+css: [/css/holiday-card/2020.css]
 ---

--- a/holiday-card/2021/index.html
+++ b/holiday-card/2021/index.html
@@ -24,7 +24,7 @@ css: [/css/holiday-card/2021.css]
 
 <section class="card-content">
   <p>Hi there!</p>
-  <p>We wanted to take a moment to say thank you for being a part of our community.</p>
+  <p>We wanted to take a moment to say <em>thank you</em> for being a part of our community.</p>
   <p>Wishing you a happy and healthy new year.</p>
   <p>Let's learn something new in 2022!</p>
   <p>&mdash; The Gymnasium Team</p>

--- a/holiday-card/2021/index.html
+++ b/holiday-card/2021/index.html
@@ -1,9 +1,23 @@
 ---
 layout: wrapper-full-white
 permalink: /holiday-card/2021/
+# This css is here for localhost display only (see the meta tag for the tag used on the live sites)
+css: [/css/holiday-card/2021.css]
 ---
+
 <header>
   <h1>2021 Holiday Card</h1>
   <p>Season's greetings from Aquent Gymnasium.</p>
 </header>
+<pre class="gym-custom-css">
+<code class="gym-custom-css">
+<span class="token style">&lt;style&gt;</span>
+<span class="token comment">/* thegymnasium.com */</span>
+<span class="token selector">.gymnasium</span> {
+  <span class="token property">content</span>: <span class="token string">"Keep learning! 🎉"</span>;
+  <span class="token property">will-change</span>: <span class="token string">transform</span>;
+}
+<span class="token style">&lt;/style&gt;</span>
+</code>
 
+</pre>

--- a/holiday-card/2021/index.html
+++ b/holiday-card/2021/index.html
@@ -11,13 +11,13 @@ css: [/css/holiday-card/2021.css]
 <section>
 <pre class="gym-custom-css">
 <code class="gym-custom-css">
-<span class="token style">&lt;style&gt;</span>
+<span class="token tag">&lt;style&gt;</span>
 <span class="token comment">/* thegymnasium.com */</span>
 <span class="token selector">.gymnasium</span> {
   <span class="token property">content</span>: <span class="token string">"Keep learning! 🎉"</span>;
   <span class="token property">will-change</span>: <span class="token string">transform</span>;
 }
-<span class="token style">&lt;/style&gt;</span>
+<span class="token tag">&lt;/style&gt;</span>
 </code>
 </pre>
 </section>

--- a/holiday-card/2021/index.html
+++ b/holiday-card/2021/index.html
@@ -4,11 +4,11 @@ permalink: /holiday-card/2021/
 # This css is here for localhost display only (see the meta tag for the tag used on the live sites)
 css: [/css/holiday-card/2021.css]
 ---
-
 <header>
   <h1>2021 Holiday Card</h1>
-  <p>Season's greetings from Aquent Gymnasium.</p>
 </header>
+
+<section>
 <pre class="gym-custom-css">
 <code class="gym-custom-css">
 <span class="token style">&lt;style&gt;</span>
@@ -19,5 +19,13 @@ css: [/css/holiday-card/2021.css]
 }
 <span class="token style">&lt;/style&gt;</span>
 </code>
-
 </pre>
+</section>
+
+<section class="card-content">
+  <p>Hi there!</p>
+  <p>We wanted to take a moment to say thank you for being a part of our community.</p>
+  <p>Wishing you a happy and healthy new year.</p>
+  <p>Let's learn something new in 2022!</p>
+  <p>&mdash; The Gymnasium Team</p>
+</section>

--- a/holiday-card/2021/meta.md
+++ b/holiday-card/2021/meta.md
@@ -6,4 +6,5 @@ og_title: "2021 Holiday Card"
 og_description: "Season's greetings from Aquent Gymnasium."
 og_art: /img/brand/og/gym-brand-og.png
 og_url: https://thegymnasium.com/holiday-card/2021
+css: ['/css/holiday-card/2021.css']
 ---

--- a/holiday-card/2022/index.html
+++ b/holiday-card/2022/index.html
@@ -1,6 +1,7 @@
 ---
 layout: wrapper-full-white
 permalink: /holiday-card/2022/
+css: [/css/holiday-card/2022.css]
 ---
 <header>
   <h1>2022 Holiday Card</h1>

--- a/holiday-card/2022/meta.md
+++ b/holiday-card/2022/meta.md
@@ -6,4 +6,5 @@ og_title: "2022 Holiday Card"
 og_description: "Season's greetings from Aquent Gymnasium."
 og_art: /img/brand/og/gym-brand-og.png
 og_url: https://thegymnasium.com/holiday-card/2022
+css: [/css/holiday-card/2022.css]
 ---

--- a/hub-pages/accessibility/index.html
+++ b/hub-pages/accessibility/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /accessibility/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/accessibility/meta.md
+++ b/hub-pages/accessibility/meta.md
@@ -6,4 +6,5 @@ og_title: "Accessibility Collection"
 og_description: "Explore our free collection of accessibility courses, tutorials, resources, and services."
 og_art: /img/hub-pages/og/accessibility-collection-og.png
 og_url: https://thegymnasium.com/accessibility
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/career-skills/index.html
+++ b/hub-pages/career-skills/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /career-skills/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/career-skills/meta.md
+++ b/hub-pages/career-skills/meta.md
@@ -6,4 +6,5 @@ og_title: "Career Skills Collection"
 og_description: "Explore our free collection of career skill courses, tutorials, webinars, articles, and jobs."
 og_art: /img/hub-pages/og/career-skills-collection-og.png
 og_url: https://thegymnasium.com/career-skills
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/collections/collections.html
+++ b/hub-pages/collections/collections.html
@@ -1,10 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /collections/
-
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="hight">
-
 <main id="main" role="main">
   <header class="collections--about" id="about">
     <div class="container">

--- a/hub-pages/collections/meta.md
+++ b/hub-pages/collections/meta.md
@@ -6,4 +6,5 @@ og_title: "Content Collections"
 og_description: "Explore a specific topic and learn practical skills with free courses, tutorials, and resources."
 og_art: /img/hub-pages/og/collections-og.png
 og_url: https://thegymnasium.com/collections
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/design-systems/index.html
+++ b/hub-pages/design-systems/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /design-systems/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main class="design-systems" id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/design-systems/meta.md
+++ b/hub-pages/design-systems/meta.md
@@ -6,4 +6,5 @@ og_title: "Design Systems Collection"
 og_description: "Explore our free collection of design systems courses taught by Ethan Marcotte."
 og_art: /img/hub-pages/og/design-systems-collection-og.png
 og_url: https://thegymnasium.com/design-systems
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/prototyping/index.html
+++ b/hub-pages/prototyping/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /prototyping/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/prototyping/meta.md
+++ b/hub-pages/prototyping/meta.md
@@ -6,4 +6,5 @@ og_title: "Prototyping Collection"
 og_description: "Explore our free collection of prototyping courses, tutorials, webinars, articles, and jobs."
 og_art: /img/hub-pages/og/prototyping-collection-og.png
 og_url: https://thegymnasium.com/prototyping
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/remote-work/index.html
+++ b/hub-pages/remote-work/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /remote-work/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/remote-work/meta.md
+++ b/hub-pages/remote-work/meta.md
@@ -6,4 +6,5 @@ og_title: "Remote Work Resources"
 og_description: "Explore our free collection of remote work resources and jobs for workers, managers, and educators and students."
 og_art: /img/hub-pages/og/remote-work-resources-og.png
 og_url: https://thegymnasium.com/remote-work
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/ux-design/index.html
+++ b/hub-pages/ux-design/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /ux-design/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
 
   <section id="about">

--- a/hub-pages/ux-design/meta.md
+++ b/hub-pages/ux-design/meta.md
@@ -6,4 +6,5 @@ og_title: "UX Design Collection"
 og_description: "Explore our free collection of UX courses, tutorials, webinars, articles, and jobs."
 og_art: /img/hub-pages/og/ux-design-collection-og.png
 og_url: https://thegymnasium.com/ux-design
+css: [/css/hub-pages.css]
 ---

--- a/hub-pages/web-development/index.html
+++ b/hub-pages/web-development/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /web-development/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/hub-pages/web-development/meta.md
+++ b/hub-pages/web-development/meta.md
@@ -6,4 +6,5 @@ og_title: "Web Development Collection"
 og_description: "Explore our free collection of web development courses, tutorials, webinars, articles, and jobs."
 og_art: /img/hub-pages/og/web-development-collection-og.png
 og_url: https://thegymnasium.com/web-development
+css: [/css/hub-pages.css]
 ---

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,9 +1,8 @@
 ---
 layout: wrapper-full-default
 permalink: /jobs/
+css: [/css/hub-pages.css]
 ---
-<link rel="stylesheet" href="{{ site.url }}/css/hub-pages.css?{{ site.time | date:'%s' }}" fetchpriority="high">
-
 <main id="main" role="main">
   <section id="about">
     <div class="banner-content container-fluid">

--- a/jobs/meta.md
+++ b/jobs/meta.md
@@ -6,4 +6,5 @@ og_title: "Jobs"
 og_description: "Design a career you love with free resources for creative professionals."
 og_art: /img/jobs/og/jobs-og.png
 og_url: https://thegymnasium.com/jobs
+css: [/css/hub-pages.css]
 ---

--- a/static-pages/404/index.html
+++ b/static-pages/404/index.html
@@ -1,11 +1,8 @@
 ---
 layout: wrapper-full-white
 permalink: /404/
+css: [/css/static-main-content.css]
 ---
-{%- if site.environment == 'local' -%}
-<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-{%- endif -%}
-
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
 

--- a/static-pages/about/index.html
+++ b/static-pages/about/index.html
@@ -1,11 +1,8 @@
 ---
 layout: wrapper-75-25
 permalink: /about/
+css: [/css/static-main-content.css]
 ---
-{%- if site.environment == 'local' -%}
-<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-{%- endif -%}
-
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
 

--- a/static-pages/faq/index.html
+++ b/static-pages/faq/index.html
@@ -1,11 +1,8 @@
 ---
 layout: wrapper-75-25
 permalink: /faq/
+css: [/css/static-main-content.css]
 ---
-{%- if site.environment == 'local' -%}
-<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-{%- endif -%}
-
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
 

--- a/static-pages/privacy-policy/index.html
+++ b/static-pages/privacy-policy/index.html
@@ -1,10 +1,8 @@
 ---
 layout: wrapper-full-white
 permalink: /privacy-policy/
+css: [/css/privacy-policy.css]
 ---
-
-<link rel="stylesheet" href="{{ site.url }}/css/privacy-policy.css">
-
 <main class="privacy-policy" id="main">
 
 <nav>

--- a/static-pages/privacy-policy/meta.md
+++ b/static-pages/privacy-policy/meta.md
@@ -8,4 +8,5 @@ og_description: "Design a career you love with free online courses on design, de
 og_keywords: "free online courses designers design user experience UX javascript node nodejs sketch wordpress drupal UI"
 og_art: /img/brand/og/gym-brand-og.png
 og_url: https://thegymnasium.com/privacy
+css: [/css/privacy-policy.css]
 ---

--- a/static-pages/social-impact/index.html
+++ b/static-pages/social-impact/index.html
@@ -1,11 +1,8 @@
 ---
 layout: wrapper-full-white
 permalink: /social-impact/
+css: [/css/static-main-content.css]
 ---
-{%- if site.environment == 'local' -%}
-<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-{%- endif -%}
-
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
 

--- a/static-pages/support/index.html
+++ b/static-pages/support/index.html
@@ -1,11 +1,8 @@
 ---
 layout: wrapper-75-25
 permalink: /support/
+css: [/css/static-main-content.css]
 ---
-{%- if site.environment == 'local' -%}
-<link rel="stylesheet" href="{{ site.url }}/css/static-main-content.css?{{ site.time | date:'%s' }}">
-{%- endif -%}
-
 <!-- Temporary HTML for style hooks -->
 <div class="main-content-static">
 

--- a/take5/catalog-blitz.html
+++ b/take5/catalog-blitz.html
@@ -1,6 +1,7 @@
 ---
 layout: wrapper-full-default
 permalink: /take5/blitz
+css: [/css/take5.css]
 ---
 {%- comment -%}
 //
@@ -9,8 +10,6 @@ permalink: /take5/blitz
 {%- endcomment -%}
 
 {% assign base_path = "/courses/take5/" | prepend: site.gymurl %}
-
-<link rel="stylesheet" href="{{ site.url }}/css/take5.css">
 
 {%- include take5/detail-opener-js.html -%}
 

--- a/take5/catalog-debug.html
+++ b/take5/catalog-debug.html
@@ -1,6 +1,7 @@
 ---
 layout: wrapper-full-default
 permalink: /take5/debug
+css: [/css/take5.css]
 ---
 
 {%- comment -%}
@@ -9,7 +10,6 @@ permalink: /take5/debug
 //
 {%- endcomment -%}
 
-<link rel="stylesheet" href="https://thegymcms.com/css/take-5.css">
 <main id="main" role="main">
 <h1 class="title all-caps">Take 5 Catalog Page</h1>
 


### PR DESCRIPTION
## What this PR does:
- adds HTML/CSS based recreation of the 2020n & 2021 holiday cards

## Extra
- streamlines localhost behavior for CSS files (essentially moves references to CSS files out of the content to the head via liquid tags)


## Preview (screencap)
<img width="1162" alt="Screen Shot 2022-12-16 at 4 04 51 PM" src="https://user-images.githubusercontent.com/1010395/208188773-f9e6f46b-08f6-49a1-87ae-b972446af814.png">
<img width="1160" alt="Screen Shot 2022-12-16 at 3 12 56 PM" src="https://user-images.githubusercontent.com/1010395/208181630-1b378874-a3d0-4fe3-ae83-7345a4f35992.png">
