### PR TITLE
[Release]: patch to correct incorrect job feed path

### DIFF
--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -119,6 +119,15 @@ class GymJobs {
       const msgContainer = document.getElementById('messages');
       const form = document.getElementById('m');
 
+      // Off-site preference key
+      let remoteLegend = {
+        0: "Unknown",
+        1: "On-Site",
+        2: "Off-Site",
+        3: "Either",
+        4: "Partial on-site",
+      }
+
       if (jobsContainer.hasAttribute('data-options')) {
         parseOptions(jobsContainer.getAttribute('data-options'),opts);
       }
@@ -382,6 +391,9 @@ class GymJobs {
             // Generate job item
             for (var i = 0; i < limit; i++) {
               var el = items[i];
+
+              outputDebug(`[job module] job id ${el.id} remote type: ${remoteLegend[el.remote]}`);
+
               list += '<li>';
               // Add optional heading prefix
               if (optHeading) {

--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,4 +1,4 @@
-{%- assign jobs_endpoint = "/apps/gym/jobs.json" | prepend: site.gymurl -%}
+{%- assign jobs_endpoint = "/feeds/jobs.json" | prepend: site.gymurl -%}
 {%- assign jobs_fallback = "/feeds/jobs.json" | prepend: site.url -%}
 
 {%- if site.environment == "local" -%}

--- a/_local_config.yml
+++ b/_local_config.yml
@@ -48,7 +48,7 @@ plugins:
 ## JSON Fetch
 jekyll_get_json:
   - data: jobs
-    json: 'https://stag-assets.aquent.com/apps/gym/jobs.json?limit=1500'
+    json: 'https://stag-assets.aquent.com/apps/gym/jobs.json?limit=50'
   - data: markets
     json: 'https://stag-assets.aquent.com/apps/gym/markets.json'
   # - data: privacy-index


### PR DESCRIPTION
The job feed is a little messed up right now - turns out we were using the fallback instead of the actual jobs feed (and therefore we have stale jobs on production again). This fix resolves it (hopefully for good).

Unrelated: also includes a newly defined, unused variable and a config thing to help speed up localhost build times.