### PR TITLE
[Feature/Patch]: Job Feed Improvements

### DIFF
--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -101,344 +101,255 @@ function parseOptions(input, output) {
   });
 }
 
-class GymJobs {
-  constructor() {}
+function processJobs(JSONP) {
+  const jobsContainer = document.getElementById('jobs-container');
 
-  loadJobs() {
+  if (typeof jobsContainer !== 'undefined' && jobsContainer !== null) {
+    var opts = {};
+    var debug = getUrlParameter('debug') ? true : false;
+    var data;
+    var url = new URL(window.location.href);
+    const msgContainer = document.getElementById('messages');
+    const form = document.getElementById('m');
 
-    const jobsContainer = document.getElementById('jobs-container');
+    // Off-site preference key
+    let remoteLegend = {
+      0: "Unknown",
+      1: "On-Site",
+      2: "Off-Site",
+      3: "Either",
+      4: "Partial on-site",
+    }
 
-    if (typeof jobsContainer !== 'undefined' && jobsContainer !== null) {
-      var opts = {};
-      var debug = getUrlParameter('debug') ? true : false;
-      var data;
-      var endpoint;
-      var fallback;
-      var endpointExists = false;
-      var url = new URL(window.location.href);
-      const msgContainer = document.getElementById('messages');
-      const form = document.getElementById('m');
+    if (jobsContainer.hasAttribute('data-options')) {
+      parseOptions(jobsContainer.getAttribute('data-options'),opts);
+    }
+    
+    if (jobsContainer.hasAttribute('data-endpoint')) {
+      endpoint = jobsContainer.getAttribute('data-endpoint');
+    }
+    
+    if (jobsContainer.hasAttribute('data-fallback')) {
+      fallback = jobsContainer.getAttribute('data-fallback');
+    }
 
-      // Off-site preference key
-      let remoteLegend = {
-        0: "Unknown",
-        1: "On-Site",
-        2: "Off-Site",
-        3: "Either",
-        4: "Partial on-site",
+    
+    // Add exception for `remote` option in the markets dropdown
+    var market = getUrlParameter('m') === 'remote' ? undefined : getUrlParameter('m');
+    
+    // If we have a market populated on page load, update the dropdown
+    if (typeof market !== 'undefined' && market !== null && market.length) {
+      updateDropdown(market);
+    }
+    
+    function outputDebug(message) {
+      if (debug) {
+        console.log(message);
       }
-
-      if (jobsContainer.hasAttribute('data-options')) {
-        parseOptions(jobsContainer.getAttribute('data-options'),opts);
+    }
+    
+    // Clear results completely
+    function clearResults() {
+      jobsContainer.innerHTML = '';
+    }
+    
+    // What to do when the select updates
+    function selectChange() {
+      var value = this.value
+      if (value === 'remote') {
+        market = undefined;
+      } else {
+        market = value;
       }
-      
-      if (jobsContainer.hasAttribute('data-endpoint')) {
-        endpoint = jobsContainer.getAttribute('data-endpoint');
+    
+      let params = new URLSearchParams(url.search);
+    
+      // add "topic" parameter
+      params.set('m', value);
+    
+      if(debug) {
+        params.set('debug', true);
       }
+    
+      params.toString();
+    
+      window.history.pushState({}, '', `?${params}#location`);
       
-      if (jobsContainer.hasAttribute('data-fallback')) {
-        fallback = jobsContainer.getAttribute('data-fallback');
+      outputDebug(`[job module] market selected: ${market}`);
+    
+      hideMsg();
+      clearResults();
+    
+      conductData();
+    }
+    
+    // Update dropdown to the selected option
+    function updateDropdown(m) {
+      document.querySelector(`#m [value="${m}"]`).selected = true;
+    }
+    
+    function hideMsg() {
+      // firstly, hide any visible messaging
+      msgContainer.querySelectorAll('div').forEach(el => {
+        el.classList.add('hide');
+      });
+    }
+    
+    // Show our messaging accordingly
+    function showMsg(id) {
+      // firstly, hide any visible messaging
+      hideMsg();
+    
+      // show the element we want!
+      document.getElementById(id).classList.remove('hide');
+    }
+    
+    // Store our data in session storage
+    function store(name,data) {
+      if (window.sessionStorage) {
+        sessionStorage.setItem(name, data);
+      } else {
+        console.warn('[job module] No browser support for sessionStorage!');
       }
-  
-      
-      // Add exception for `remote` option in the markets dropdown
-      var market = getUrlParameter('m') === 'remote' ? undefined : getUrlParameter('m');
-      
-      // If we have a market populated on page load, update the dropdown
-      if (typeof market !== 'undefined' && market !== null && market.length) {
-        updateDropdown(market);
-      }
-      
-      function outputDebug(message) {
-        if (debug) {
-          console.log(message);
-        }
-      }
-      
-      // Clear results completely
-      function clearResults() {
-        jobsContainer.innerHTML = '';
-      }
-      
-      // What to do when the select updates
-      function selectChange() {
-        var value = this.value
-        if (value === 'remote') {
-          market = undefined;
-        } else {
-          market = value;
-        }
-      
-        let params = new URLSearchParams(url.search);
-      
-        // add "topic" parameter
-        params.set('m', value);
-      
-        if(debug) {
-          params.set('debug', true);
-        }
-      
-        params.toString();
-      
-        window.history.pushState({}, '', `?${params}#location`);
-        
-        outputDebug(`[job module] market selected: ${market}`);
-      
-        hideMsg();
-        clearResults();
-      
-        conductData();
-      }
-      
-      // Update dropdown to the selected option
-      function updateDropdown(m) {
-        document.querySelector(`#m [value="${m}"]`).selected = true;
-      }
-      
-      function hideMsg() {
-        // firstly, hide any visible messaging
-        msgContainer.querySelectorAll('div').forEach(el => {
-          el.classList.add('hide');
-        });
-      }
-      
-      // Show our messaging accordingly
-      function showMsg(id) {
-        // firstly, hide any visible messaging
-        hideMsg();
-      
-        // show the element we want!
-        document.getElementById(id).classList.remove('hide');
-      }
-      
-      // Store our data in session storage
-      function store(name,data) {
-        if (window.sessionStorage) {
-          sessionStorage.setItem(name, data);
-        } else {
-          console.warn('[job module] No browser support for sessionStorage!');
-        }
-      }
-      
-      function handleEvent(e) {
-        outputDebug(`[job module] ${e.type}: ${e.loaded} bytes transferred\n`)
-      
-        if (e.type === 'error' || e.type === 'abort') {
-          endpointExists = false;
-        } else if (e.type === 'loadend') {
-          endpointExists = true;
-        }
-      }
-      
-      function addListeners(xhr) {
-        xhr.addEventListener('loadstart', handleEvent);
-        xhr.addEventListener('load', handleEvent);
-        xhr.addEventListener('loadend', handleEvent);
-        xhr.addEventListener('progress', handleEvent);
-        xhr.addEventListener('error', handleEvent);
-        xhr.addEventListener('abort', handleEvent);
-      }
-      
-      function testEndpoint(url, cb) {
-        var request = new XMLHttpRequest();
-      
-        addListeners(request);
-        request.open('GET', url, true);
-      
-        request.send();
-      
-        if (cb) {
-          cb();
-        }
-      }
-      
-      // AJAX fetch
-      function fetchData(url) {
-      
-        var request = new XMLHttpRequest();
-        
-        request.open('GET', url, true);
-      
-        request.send();
-      
-        request.onload = function() {
-      
-          if (this.status >= 200 && this.status < 400) {
-            if (typeof this.response !== "undefined" && this.response !== null) {
-              var response = this.response;
-      
-              store('jobs', response);
-      
-              outputDebug(`[job module] fetching data from endpoint: ${endpoint}`);
-      
-              processData(response);
-      
-            } else {
-              // No jobs in market (or there was no data)! Show the appropriate message.
-              showMsg('error-results');
-            }
-          } else {
-            // We reached our target server, but it returned an error
-            showMsg('error-server');
-          }
-        };
-      
-        request.onerror = function() {
-          // There was a connection error of some sort
-          showMsg('error-connection');
-        };
-      
-        request.onabort = function() {
-          // There was a connection error of some sort
-          showMsg('error-connection');
-        };
-      }
-      
-      function conductData() {
-        // If we have jobs stored locally already in the browser session...
-        if (window.sessionStorage && sessionStorage.getItem('jobs')) {
+    }
+    
+    function conductData() {
+      // If we have jobs stored locally already in the browser session...
+      if (window.sessionStorage && sessionStorage.getItem('jobs')) {
+        try {
           data = sessionStorage.getItem('jobs');
-      
+    
           outputDebug('[job module] data from sessionStorage');
       
-          processData(data);
-        } else {
-      
-          try {
-            testEndpoint(`${endpoint}?limit=1`, function(){
-              outputDebug(`[job module] endpoint ${endpoint} exists: ${endpointExists}`)
-              if (endpointExists) {
-                endpoint += '?limit=1500';
-              } else {
-                endpoint = fallback;
-              }
-      
-              outputDebug(`[job module] fetching ${endpoint}`);
-      
-              fetchData(endpoint);
-            });
-      
-          } catch(err) {
-      
-            console.warn('[job module] some type of error occurred, reverting to local feed! ', err);
-      
-            endpoint = fallback;
-      
-            fetchData(endpoint);
-          }
+        } catch(err) {
+          console.warn('[job module] error retrieving sessionStorage data.', err);
+        }
+
+      } else {
+    
+        try {
+          outputDebug(`[job module] storing JSONP data.`);
+
+          data = JSON.stringify(JSONP);
+          store('jobs', data);
+    
+        } catch(err) {
+          console.warn('[job module] error storing/processing JSONP!', err);
         }
       }
-      
-      // Process our JSON data
-      function processData(d) {
-        data = JSON.parse(d);
-        if (typeof data.items !== 'undefined' && data.items !== null) {
-          
-          var items = data.items;
 
-          outputDebug(`[job module] ${items.length} total jobs available.`);
-      
-          // Wrap our jobs in headings or no?
-          var optHeading = opts.heading ? opts.heading : false;
-        
-          // Do we have a specific category?
-          var category = opts.category ? opts.category : false;
-        
-          // Set iteration limits
-          var limit = opts.limit ? parseInt(opts.limit) : 10;
-        
-          if (category) {
-            items = items.filter(item => item.category === category);
-        
-            outputDebug(`[job module] showing up to ${items.length} jobs for category: ${category}.`);
-          }
-        
-          // Filter the jobs by market if we have a market param
-          if ((typeof market !== 'undefined' && market !== null) && market.length) {
-            items = items.filter(item => item.market === market);
-        
-            outputDebug(`[job module] showing up to ${items.length} jobs for market: ${market}.`);
-          } else {
-            // Off-site preference key
-            // 0 = Unknown
-            // 1 = On-Site
-            // 2 = Off-Site
-            // 3 = Either
-            // 4 = Partial on-site
-            items = items.filter(item => parseInt(item.remote) >= 2);
-            updateDropdown('remote');
-        
-            outputDebug('[job module] showing only remote & hybrid options…');
-          }
-        
-          // How many results do we have?
-          var numResults = items.length;
-        
-          outputDebug(`[job module] total results: ${numResults} | limit: ${limit}`);
-        
-          if (numResults > 0) {
-            
-            // Start with an empty list
-            var list = "";
-        
-            // hide our loading message
-            document.getElementById('loading').classList.add('hide');
-        
-            if (numResults < limit) {
-              limit = numResults;
-            }
-        
-            // Generate job item
-            for (var i = 0; i < limit; i++) {
-              var el = items[i];
-
-              outputDebug(`[job module] job id ${el.id} remote type: ${remoteLegend[el.remote]}`);
-
-              list += '<li>';
-              // Add optional heading prefix
-              if (optHeading) {
-                list += `<${optHeading}>`;
-              }
-              list += `<a href="${decodeURI(el.url)}?utm_source=gymnasium&utm_medium=web&utm_campaign=job-module&utm_content=textlink" title="${el.title}"><span class="job-title">${el.title} </span><span class="job-location"> ${el.city}</span></a>`;
-              if (optHeading) {
-                list += `</${optHeading}>`;
-              }
-              list += '</li>';
-            }
-        
-            // close our list
-            jobsContainer.innerHTML += `<ul>${list}</ul>`;
-          } else {
-            // No jobs in market! Show the appropriate message.
-            showMsg('error-results');
-          }
-        } else {
-          // No data found for some reason...
-          showMsg('error-unknown');
-        }
+      try {
+        processData(data);
+      } catch(err) {
+        console.warn('[job module] error processing data!', err);
       }
-      
-      conductData();
-      
-      // Listen for change events from form select
-      form.addEventListener('change', selectChange, false);
-
-      /* Currently unused/inactive
-      // Listen for geolocator messages from our iframe
-      eventer(messageEvent,function(event) {
-        // Reject messages that are not from a valid origin domain
-        const regex = new RegExp('https:\/\/.*assets.aquent.com');
-        if (regex.test(event.origin)) {
-          outputDebug(`[geolocator] ${event.data}`);
-      
-          parseOptions(event.data,opts);
-        }
-      }, false);
-      */
     }
+    
+    // Process our JSON data
+    function processData(d) {
+      data = JSON.parse(d);
+      if (typeof data.items !== 'undefined' && data.items !== null) {
+        
+        var items = data.items;
+
+        outputDebug(`[job module] ${items.length} total jobs available.`);
+    
+        // Wrap our jobs in headings or no?
+        var optHeading = opts.heading ? opts.heading : false;
+      
+        // Do we have a specific category?
+        var category = opts.category ? opts.category : false;
+      
+        // Set iteration limits
+        var limit = opts.limit ? parseInt(opts.limit) : 10;
+      
+        if (category) {
+          items = items.filter(item => item.category === category);
+      
+          outputDebug(`[job module] showing up to ${items.length} jobs for category: ${category}.`);
+        }
+      
+        // Filter the jobs by market if we have a market param
+        if ((typeof market !== 'undefined' && market !== null) && market.length) {
+          items = items.filter(item => item.market === market);
+      
+          outputDebug(`[job module] showing up to ${items.length} jobs for market: ${market}.`);
+        } else {
+          // Off-site preference key
+          // 0 = Unknown
+          // 1 = On-Site
+          // 2 = Off-Site
+          // 3 = Either
+          // 4 = Partial on-site
+          items = items.filter(item => parseInt(item.remote) >= 2);
+          updateDropdown('remote');
+      
+          outputDebug('[job module] showing only remote & hybrid options…');
+        }
+      
+        // How many results do we have?
+        var numResults = items.length;
+      
+        outputDebug(`[job module] total results: ${numResults} | limit: ${limit}`);
+      
+        if (numResults > 0) {
+          
+          // Start with an empty list
+          var list = "";
+      
+          // hide our loading message
+          document.getElementById('loading').classList.add('hide');
+      
+          if (numResults < limit) {
+            limit = numResults;
+          }
+      
+          // Generate job item
+          for (var i = 0; i < limit; i++) {
+            var el = items[i];
+
+            outputDebug(`[job module] job id ${el.id} remote type: ${remoteLegend[el.remote]}`);
+
+            list += '<li>';
+            // Add optional heading prefix
+            if (optHeading) {
+              list += `<${optHeading}>`;
+            }
+            list += `<a href="${decodeURI(el.url)}?utm_source=gymnasium&utm_medium=web&utm_campaign=job-module&utm_content=textlink" title="${el.title}"><span class="job-title">${el.title} </span><span class="job-location"> ${el.city}</span></a>`;
+            if (optHeading) {
+              list += `</${optHeading}>`;
+            }
+            list += '</li>';
+          }
+      
+          // close our list
+          jobsContainer.innerHTML += `<ul>${list}</ul>`;
+        } else {
+          // No jobs in market! Show the appropriate message.
+          showMsg('error-results');
+        }
+      } else {
+        // No data found for some reason...
+        showMsg('error-unknown');
+      }
+    }
+    
+    conductData();
+    
+    // Listen for change events from form select
+    form.addEventListener('change', selectChange, false);
+
+    /* Currently unused/inactive
+    // Listen for geolocator messages from our iframe
+    eventer(messageEvent,function(event) {
+      // Reject messages that are not from a valid origin domain
+      const regex = new RegExp('https:\/\/.*assets.aquent.com');
+      if (regex.test(event.origin)) {
+        outputDebug(`[geolocator] ${event.data}`);
+    
+        parseOptions(event.data,opts);
+      }
+    }, false);
+    */
   }
 }
-
-var gymjobs = new GymJobs();
-
-gymjobs.loadJobs();

--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -253,7 +253,7 @@ function processJobs(JSONP) {
       
         // Set iteration limits
         var limit = opts.limit ? parseInt(opts.limit) : 10;
-      
+
         if (category) {
           items = items.filter(item => item.category === category);
       
@@ -284,6 +284,19 @@ function processJobs(JSONP) {
         outputDebug(`[job module] total results: ${numResults} | limit: ${limit}`);
       
         if (numResults > 0) {
+          // Sort array by mod/post date properly, whichever is more recent
+          items = items.sort((a, b) => {
+            
+            const aModDate = new Date(a.modDate).getTime();
+            const aPostDate = new Date(a.postedDate).getTime();
+            const bModDate = new Date(b.modDate).getTime();
+            const bPostDate = new Date(b.postedDate).getTime();
+
+            const compA = aModDate > aPostDate ? aModDate : aPostDate;
+            const compB = bModDate > bPostDate ? bModDate : bPostDate;
+
+            return compB - compA;
+          });
           
           // Start with an empty list
           var list = "";
@@ -298,8 +311,10 @@ function processJobs(JSONP) {
           // Generate job item
           for (var i = 0; i < limit; i++) {
             var el = items[i];
+            var postDate = el.postedDate;
+            var modDate = el.modDate;
 
-            outputDebug(`[job module] job id ${el.id} remote type: ${remoteLegend[el.remote]}`);
+            outputDebug(`[job module] job id: ${el.id}\n   remote type: ${remoteLegend[el.remote]}\n   posted: ${postDate}\n   mod date: ${modDate}`);
 
             list += '<li>';
             // Add optional heading prefix

--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -109,6 +109,7 @@ function processJobs(JSONP) {
     var debug = getUrlParameter('debug') ? true : false;
     var data;
     var url = new URL(window.location.href);
+    var selectedMarket;
     const msgContainer = document.getElementById('messages');
     const form = document.getElementById('m');
 
@@ -263,8 +264,10 @@ function processJobs(JSONP) {
         // Filter the jobs by market if we have a market param
         if ((typeof market !== 'undefined' && market !== null) && market.length) {
           items = items.filter(item => item.market === market);
+
+          selectedMarket = document.querySelector(`#m [value="${market}"]`).innerText;
       
-          outputDebug(`[job module] showing ${items.length} jobs for market: ${market}.`);
+          outputDebug(`[job module] showing ${items.length} jobs for market: ${market}, aka ${selectedMarket}`);
         } else {
           // Off-site preference key
           // 0 = Unknown

--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -257,14 +257,14 @@ function processJobs(JSONP) {
         if (category) {
           items = items.filter(item => item.category === category);
       
-          outputDebug(`[job module] showing up to ${items.length} jobs for category: ${category}.`);
+          outputDebug(`[job module] showing ${items.length} jobs for category: ${category}.`);
         }
       
         // Filter the jobs by market if we have a market param
         if ((typeof market !== 'undefined' && market !== null) && market.length) {
           items = items.filter(item => item.market === market);
       
-          outputDebug(`[job module] showing up to ${items.length} jobs for market: ${market}.`);
+          outputDebug(`[job module] showing ${items.length} jobs for market: ${market}.`);
         } else {
           // Off-site preference key
           // 0 = Unknown

--- a/_includes/js/jobs.js
+++ b/_includes/js/jobs.js
@@ -125,15 +125,6 @@ function processJobs(JSONP) {
       parseOptions(jobsContainer.getAttribute('data-options'),opts);
     }
     
-    if (jobsContainer.hasAttribute('data-endpoint')) {
-      endpoint = jobsContainer.getAttribute('data-endpoint');
-    }
-    
-    if (jobsContainer.hasAttribute('data-fallback')) {
-      fallback = jobsContainer.getAttribute('data-fallback');
-    }
-
-    
     // Add exception for `remote` option in the markets dropdown
     var market = getUrlParameter('m') === 'remote' ? undefined : getUrlParameter('m');
     

--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -1,10 +1,4 @@
-{%- assign jobs_endpoint = "/feeds/jobs.json" | prepend: site.gymurl -%}
-{%- assign jobs_fallback = "/feeds/jobs.json" | prepend: site.url -%}
-
-{%- if site.environment == "local" -%}
-  {%- assign jobs_endpoint = "/feeds/jobs.json" -%}
-  {%- assign jobs_fallback = jobs_endpoint -%}
-{%- endif -%}
+{%- assign jobs_endpoint = "/apps/gym/jobs.json" | prepend: site.aqassetsurl -%}
 
 {%- assign markets_au = site.data.markets.items | where: "countryCode", "AU" -%}
 {%- assign markets_ca = site.data.markets.items | where: "countryCode", "CA" -%}
@@ -98,5 +92,5 @@
     <p>We were unable to retrieve jobs because of an unknown error. Please try again later.</p>
   </div>
 </div>
-<div id="jobs-container" class="jobs-container {{jobs_module_class}}" data-options="heading:{{opt_heading}};category:{{opt_category | downcase}};limit:{{opt_limit}};" data-endpoint="{{jobs_endpoint}}" data-fallback="{{jobs_fallback}}"></div><!-- #jobs-container.jobs-container.{{jobs_module_class}} -->
-<script async defer src="https://assets.aquent.com/apps/gym/jobs.json?limit=1500&callback=processJobs"></script>
+<div id="jobs-container" class="jobs-container {{jobs_module_class}}" data-options="heading:{{opt_heading}};category:{{opt_category | downcase}};limit:{{opt_limit}};"></div><!-- #jobs-container.jobs-container.{{jobs_module_class}} -->
+<script async defer src="{{jobs_endpoint}}?limit=1500&callback=processJobs"></script>

--- a/_includes/modules/jobs.html
+++ b/_includes/modules/jobs.html
@@ -99,3 +99,4 @@
   </div>
 </div>
 <div id="jobs-container" class="jobs-container {{jobs_module_class}}" data-options="heading:{{opt_heading}};category:{{opt_category | downcase}};limit:{{opt_limit}};" data-endpoint="{{jobs_endpoint}}" data-fallback="{{jobs_fallback}}"></div><!-- #jobs-container.jobs-container.{{jobs_module_class}} -->
+<script async defer src="https://assets.aquent.com/apps/gym/jobs.json?limit=1500&callback=processJobs"></script>


### PR DESCRIPTION
### The Current Problem(s)
A. The jobs feed seems to run into issues with reliably fetching jobs from the Aquent endpoint, and it seems to be because of CORS errors. This is surprising and frustrating because the our sites are already on the allow list for cross-origin requests. As a result of these errors, the job feed has been consistently using the fallback feed, which is only as recent as the last gymcms build (for each corresponding server - dev, staging, production).
B. For some reason, the date sorting provided by the dotCMS feed is wonky at best. We have the potential to sort by `posted date` or `mod date` and the feed doesn't do it properly.

### What this update does:
- Avoids CORS errors by using JSONP to reliably fetch jobs. It's kind of an old school method at this point, but it seems to work better than our previous approaches.
- Eliminates the fallback option, to ensure we're seeing errors in real time should the job feed fail for whatever reason. In the future, I hope to implement a type of notification system for that (maybe via a 3rd party). Everything in increments.
- Implements proper sorting by date - we compare the `posted date` and the `mod date` to see which is more recent.

### Testing:
- Visit https://gymnasium.dev/jobs in an incognito window (I'm using Chrome's inspector, so you'll have to adjust the tab names specified below for other browsers)
- open up inspector (right click anywhere on the page).
- Click on the "Application" tab, and look for "Session Storage". Open it up and look for a key named "jobs". Click on the key and look at the `date_modified` field - it should be roughly the time you opened up the page. Now, select the key again and delete it. Yes, delete it. We're going to have you load the jobs anew while looking at the console.
- click on the "Console" tab. In the upper left corner is an icon that looks like a circle with a diagonal line through it (like a stop icon). Click on it, and this will clear the console.
- Add ?debug=true to the URL, like so `https://gymnasium.dev/jobs?debug=true` and click enter. Make a note of the current time, by the way.
- You should see several lines of stuff with the prefix `job module`, and there should be a reference to `JSONP` in there.  Try messing around with the location dropdown, and you should see all of this debug data change to match your selection.
- Go back to the "Application" tab and look at the session storage again.  Check the date/time stamp and it should match when you added the debug option to the URL.