### PR TITLE
Update main navigation tab style

### DIFF
--- a/_sass/components/_navigation.scss
+++ b/_sass/components/_navigation.scss
@@ -166,6 +166,17 @@
   }
 }
 
+// Exclude courseware-related about pages /courseware/*/*/about from /courses page(s)
+
+.gym-course-about {
+  .main-nav {
+    .vbar a {
+      background-color: transparent;
+      box-shadow: none;
+    }
+  }
+}
+
 .utility-nav {
   display: none;
   background-color: black;

--- a/_sass/components/_navigation.scss
+++ b/_sass/components/_navigation.scss
@@ -61,7 +61,7 @@
       }
     }
 
-    li.active {
+    li.active a {
       background-color: #292929;
     }
 
@@ -101,7 +101,7 @@
         display: inline;
         word-spacing: 0; // Undo inherit
 
-        &.active {
+        &.active a {
           box-shadow: 0 -1.5rem #292929, 0 1.5rem #292929; // top/bottom
         }
 

--- a/_sass/components/_navigation.scss
+++ b/_sass/components/_navigation.scss
@@ -167,7 +167,7 @@
 }
 
 // Exclude courseware-related about pages /courseware/*/*/about from /courses page(s)
-
+// TODO: clean up after theme update is complete
 .gym-course-about {
   .main-nav {
     .vbar a {


### PR DESCRIPTION
## What this PR does

- Updates main navigation tab style
  - To avoid styling vertical bar pseudo-content as seen in "About" tab below

### Design Preview

**Before:**

![gym-main-nav-tab-about-before](https://user-images.githubusercontent.com/5142085/228332647-df355094-a67c-4655-a0a7-5e515aca9229.png)

**After:**

![gym-main-nav-tab-about-after](https://user-images.githubusercontent.com/5142085/228332633-dd8351ff-d51f-4ba6-8a01-c603c030862e.png)


