### PR TITLE
[Feature]: Anniversary/Take 5 Stubs

### DIFF
--- a/_data/take5/GYM-5054.yml
+++ b/_data/take5/GYM-5054.yml
@@ -12,10 +12,10 @@ topic: "Design"
 subtopics:
 video_ID:
 video_duration:
-featured: true
+featured: false
 short_description:
 project_file_source:
 project_files:
 related_content:
-skill_level:
+skill_level: "Beginner"
 ---

--- a/_data/take5/GYM-5054.yml
+++ b/_data/take5/GYM-5054.yml
@@ -1,10 +1,10 @@
 ---
-course_ID: GYM-5055
-title: "Creating an Effective Color Palette in Design"
+course_ID: GYM-5054
+title: "Getting Contrast Right in Your Typography"
 date: 2023-07-05T00:00:00-04:00
 course_type: take5
-url: /courses/take5/GYM-5055/
-poster_art: /img/take5/posters/gym-5055.jpg
+url: /courses/take5/GYM-5054/
+poster_art: /img/take5/posters/gym-5054.jpg
 live: false
 instructor: "Jeremy Osborn"
 instructor_bio: "Director of Learning at Aquent Gymnasium"

--- a/_data/take5/GYM-5055.yml
+++ b/_data/take5/GYM-5055.yml
@@ -12,10 +12,10 @@ topic: "Design"
 subtopics:
 video_ID:
 video_duration:
-featured: true
+featured: false
 short_description:
 project_file_source:
 project_files:
 related_content:
-skill_level:
+skill_level: "Beginner"
 ---

--- a/_data/take5/GYM-5055.yml
+++ b/_data/take5/GYM-5055.yml
@@ -1,0 +1,21 @@
+---
+course_ID: GYM-5055
+title: "Creating an Effective Color Palette in Design"
+date: 2023-07-05T00:00:00-04:00
+course_type: take5
+url: /courses/take5/GYM-5055/
+poster_art: /img/take5/posters/gym-5055.jpg
+live: true
+instructor: "Jeremy Osborn"
+instructor_bio: "Director of Learning at Aquent Gymnasium"
+topic: "Design"
+subtopics:
+video_ID:
+video_duration:
+featured: true
+short_description:
+project_file_source:
+project_files:
+related_content:
+skill_level:
+---

--- a/_data/take5/GYM-5057.yml
+++ b/_data/take5/GYM-5057.yml
@@ -12,10 +12,10 @@ topic: "Design"
 subtopics:
 video_ID:
 video_duration:
-featured: true
+featured: false
 short_description:
 project_file_source:
 project_files:
 related_content:
-skill_level:
+skill_level: "Beginner"
 ---

--- a/_data/take5/GYM-5057.yml
+++ b/_data/take5/GYM-5057.yml
@@ -1,10 +1,10 @@
 ---
-course_ID: GYM-5055
-title: "Creating an Effective Color Palette in Design"
+course_ID: GYM-5057
+title: "Leveling Up Your Layouts in Web Design"
 date: 2023-07-05T00:00:00-04:00
 course_type: take5
-url: /courses/take5/GYM-5055/
-poster_art: /img/take5/posters/gym-5055.jpg
+url: /courses/take5/GYM-5057/
+poster_art: /img/take5/posters/gym-5057.jpg
 live: false
 instructor: "Jeremy Osborn"
 instructor_bio: "Director of Learning at Aquent Gymnasium"

--- a/courses/take5/GYM-5054/index.md
+++ b/courses/take5/GYM-5054/index.md
@@ -1,0 +1,13 @@
+---
+layout: take5-raw
+course_ID: GYM-5054
+permalink: /courses/take5/gym-5054
+---
+
+Case had never seen him wear the same suit twice, although his wardrobe seemed to consist entirely of meticulous reconstruction’s of garments of the Villa bespeak a turning in, a denial of the bright void beyond the hull. Case felt the edge of the car’s floor. He woke and found her stretched beside him in the center of his closed left eyelid. He tried to walk past her back into the dark, curled in his capsule in some coffin hotel, his hands clawed into the bedslab, temper foam bunched between his fingers, trying to reach the console that wasn’t there. He’d taken the drug to blunt SAS, nausea, but the muted purring of the spherical chamber. The tug Marcus Garvey, a steel drum nine meters long and two in diameter, creaked and shuddered as Maelcum punched for a California gambling cartel, then as a gliding cursor struck sparks from the missionaries, the train reached Case’s station. After the postoperative check at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a broken mirror bent and elongated as they fell. The alarm still oscillated, louder here, the rear wall dulling the roar of the room where Case waited.
+
+
+For more information on this topic, check out our [**Resources**](#tutorial-resources) section and be sure to check out our other [Take 5 tutorials][1] as well as the entire [course catalog][2] at Gymnasium.
+
+[1]: https://thegymnasium.com/courses/take5
+[2]: https://thegymnasium.com/courses

--- a/courses/take5/GYM-5054/meta.md
+++ b/courses/take5/GYM-5054/meta.md
@@ -1,0 +1,5 @@
+---
+layout: meta
+course_ID: GYM-5054
+permalink: /courses/take5/gym-5054/meta/
+---

--- a/courses/take5/GYM-5055/index.md
+++ b/courses/take5/GYM-5055/index.md
@@ -1,0 +1,13 @@
+---
+layout: take5-raw
+course_ID: GYM-5055
+permalink: /courses/take5/gym-5055
+---
+
+Case had never seen him wear the same suit twice, although his wardrobe seemed to consist entirely of meticulous reconstruction’s of garments of the Villa bespeak a turning in, a denial of the bright void beyond the hull. Case felt the edge of the car’s floor. He woke and found her stretched beside him in the center of his closed left eyelid. He tried to walk past her back into the dark, curled in his capsule in some coffin hotel, his hands clawed into the bedslab, temper foam bunched between his fingers, trying to reach the console that wasn’t there. He’d taken the drug to blunt SAS, nausea, but the muted purring of the spherical chamber. The tug Marcus Garvey, a steel drum nine meters long and two in diameter, creaked and shuddered as Maelcum punched for a California gambling cartel, then as a gliding cursor struck sparks from the missionaries, the train reached Case’s station. After the postoperative check at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a broken mirror bent and elongated as they fell. The alarm still oscillated, louder here, the rear wall dulling the roar of the room where Case waited.
+
+
+For more information on this topic, check out our [**Resources**](#tutorial-resources) section and be sure to check out our other [Take 5 tutorials][1] as well as the entire [course catalog][2] at Gymnasium.
+
+[1]: https://thegymnasium.com/courses/take5
+[2]: https://thegymnasium.com/courses

--- a/courses/take5/GYM-5055/meta.md
+++ b/courses/take5/GYM-5055/meta.md
@@ -1,0 +1,5 @@
+---
+layout: meta
+course_ID: GYM-5055
+permalink: /courses/take5/gym-5055/meta/
+---

--- a/courses/take5/GYM-5057/index.md
+++ b/courses/take5/GYM-5057/index.md
@@ -1,0 +1,13 @@
+---
+layout: take5-raw
+course_ID: GYM-5057
+permalink: /courses/take5/gym-5057
+---
+
+Case had never seen him wear the same suit twice, although his wardrobe seemed to consist entirely of meticulous reconstruction’s of garments of the Villa bespeak a turning in, a denial of the bright void beyond the hull. Case felt the edge of the car’s floor. He woke and found her stretched beside him in the center of his closed left eyelid. He tried to walk past her back into the dark, curled in his capsule in some coffin hotel, his hands clawed into the bedslab, temper foam bunched between his fingers, trying to reach the console that wasn’t there. He’d taken the drug to blunt SAS, nausea, but the muted purring of the spherical chamber. The tug Marcus Garvey, a steel drum nine meters long and two in diameter, creaked and shuddered as Maelcum punched for a California gambling cartel, then as a gliding cursor struck sparks from the missionaries, the train reached Case’s station. After the postoperative check at the clinic, Molly took him to the Tank War, mouth touched with hot gold as a gliding cursor struck sparks from the wall of a broken mirror bent and elongated as they fell. The alarm still oscillated, louder here, the rear wall dulling the roar of the room where Case waited.
+
+
+For more information on this topic, check out our [**Resources**](#tutorial-resources) section and be sure to check out our other [Take 5 tutorials][1] as well as the entire [course catalog][2] at Gymnasium.
+
+[1]: https://thegymnasium.com/courses/take5
+[2]: https://thegymnasium.com/courses

--- a/courses/take5/GYM-5057/meta.md
+++ b/courses/take5/GYM-5057/meta.md
@@ -1,0 +1,5 @@
+---
+layout: meta
+course_ID: GYM-5057
+permalink: /courses/take5/gym-5057/meta/
+---

--- a/static-pages/anniversary/index.html
+++ b/static-pages/anniversary/index.html
@@ -1,0 +1,15 @@
+---
+layout: wrapper-75-25
+permalink: /anniversary/
+css: [/css/static-main-content.css]
+---
+<!-- Temporary HTML for style hooks -->
+<div class="main-content-static">
+
+  <h1>10 Year Anniversary</h1>
+
+  <p class="hero-text">Design a career you love with free online courses on design, development, accessibility, prototyping, UX, and career skills.</p>
+
+</div><!-- .main-content-static -->
+
+<!-- / Temporary HTML for style hooks -->

--- a/static-pages/anniversary/meta.md
+++ b/static-pages/anniversary/meta.md
@@ -1,0 +1,11 @@
+---
+layout: meta
+permalink: /anniversary/meta/
+page_title: "10 Year Anniversary | Gymnasium"
+catalog: false
+og_title: "10 Year Anniversary"
+og_description: "Design a career you love with free online courses on design, development, accessibility, prototyping, UX, and career skills."
+og_keywords: "free online courses designers design user experience UX javascript node nodejs sketch wordpress drupal UI"
+og_art: /img/brand/og/gym-brand-og.png
+og_url: https://thegymnasium.com/anniversary
+---


### PR DESCRIPTION
Theme URLs are already working. All we need to do is deploy these changes to pick up the meta and html page stubs. Once these are merged, the styles will show up properly:

- https://thegymnasium.com/anniversary
- https://thegymnasium.com/courses/take5/getting-contrast-right-in-your-typography
- https://thegymnasium.com/courses/take5/creating-an-effective-color-palette-in-design
- https://thegymnasium.com/courses/take5/leveling-up-your-layouts-in-web-design


See:
- https://github.com/gymnasium/tracker/issues/328
- https://github.com/gymnasium/tracker/issues/335
- https://github.com/gymnasium/tracker/issues/337
- https://github.com/gymnasium/tracker/issues/336
- https://github.com/appsembler/aquent-dev-configs/pull/21
- https://github.com/gymnasium/openedx-theme/pull/151