### PR TITLE
Bug: attempt cookie banner button color repair

### DIFF
--- a/_includes/partials/footer.html
+++ b/_includes/partials/footer.html
@@ -136,6 +136,6 @@ JS or tracking pixels to be included at the bottom of the theme
 {%- endcomment -%}
 
 <script id="mainjs" async defer src="{{site.url}}/js/main.js?{{ site.time | date:'%s' }}"></script>
-<script id="cookiebanner" async src="{{site.url}}/js/vendor/cookiebanner.js?{{ site.time | date:'%s' }}" data-link="#f89820" data-fg="inherit" data-message="We use cookies to enhance your experience. By continuing to visit this site you agree to our use of cookies. Find out more about how we use cookies in our" data-linkmsg="Privacy Policy." data-moreinfo="/privacy-policy"></script>
+<script id="cookiebanner" async src="{{site.url}}/js/vendor/cookiebanner.js?{{ site.time | date:'%s' }}" data-link="#f89820" data-fg="null" data-message="We use cookies to enhance your experience. By continuing to visit this site you agree to our use of cookies. Find out more about how we use cookies in our" data-linkmsg="Privacy Policy." data-moreinfo="/privacy-policy"></script>
 
 

--- a/_includes/partials/footer.html
+++ b/_includes/partials/footer.html
@@ -136,6 +136,6 @@ JS or tracking pixels to be included at the bottom of the theme
 {%- endcomment -%}
 
 <script id="mainjs" async defer src="{{site.url}}/js/main.js?{{ site.time | date:'%s' }}"></script>
-<script id="cookiebanner" async src="{{site.url}}/js/vendor/cookiebanner.js?{{ site.time | date:'%s' }}" data-link="#f89820" data-message="We use cookies to enhance your experience. By continuing to visit this site you agree to our use of cookies. Find out more about how we use cookies in our" data-linkmsg="Privacy Policy." data-moreinfo="/privacy-policy"></script>
+<script id="cookiebanner" async src="{{site.url}}/js/vendor/cookiebanner.js?{{ site.time | date:'%s' }}" data-link="#f89820" data-fg="inherit" data-message="We use cookies to enhance your experience. By continuing to visit this site you agree to our use of cookies. Find out more about how we use cookies in our" data-linkmsg="Privacy Policy." data-moreinfo="/privacy-policy"></script>
 
 


### PR DESCRIPTION
- Use data attribute to override default settings
- should resolve https://github.com/gymnasium/tracker/issues/338, even though it is hard to reproduce. (my best guess is that there's a race condition happening, because there is javascript that injects color into the banner layout)

There is no more inline color declaration on the cookiebanner div:
<img width="1333" alt="Screenshot 2023-08-04 at 10 56 30 AM" src="https://github.com/gymnasium/gymcms/assets/1010395/3540a2f8-3f6a-4a72-8722-6e65649492fd">
