### PR TITLE
[Patch]: Use career skills link on courses index

### DIFF
--- a/courses/index.html
+++ b/courses/index.html
@@ -271,7 +271,7 @@ permalink: /courses/
                       <dd><a href="{{ site.gymurl }}/ux-design">UX Design</a></dd>
                       <dd><a href="{{ site.gymurl }}/prototyping">Prototyping</a></dd>
                       <dd><a href="{{ site.gymurl }}/accessibility">Accessibility</a></dd>
-                      <dd><a href="{{ site.gymurl }}/remote-work">Remote Work</a></dd>
+                      <dd><a href="{{ site.gymurl }}/career-skills">Career Skills</a></dd>
                     </div>
                   </dl>
                 </div>

--- a/tests/collections.html
+++ b/tests/collections.html
@@ -8,7 +8,6 @@ permalink: tests/collections/
     <li><a href="/collections/">Content Collections</a></li>
     <li><a href="/design-systems/">Design Systems Collection</a></li>
     <li><a href="/accessibility/">Accessibility Collection</a></li>
-    <li><a href="/remote-work/">Remote Work Resources</a></li>
     <li><a href="/career-skills/">Career Skills Collection</a></li>
     <li><a href="/prototyping/">Prototyping Collection</a></li>
     <li><a href="/ux-design/">UX Collection</a></li>
@@ -20,7 +19,6 @@ permalink: tests/collections/
     <li><a href="/collections/meta/">Content Collections Meta</a></li>
     <li><a href="/design-systems/meta/">Design Systems Collection Meta</a></li>
     <li><a href="/accessibility/meta/">Accessibility Collection Meta</a></li>
-    <li><a href="/remote-work/meta/">Remote Work Resources Meta</a></li>
     <li><a href="/career-skills/meta/">Career Skills Collection Meta</a></li>
     <li><a href="/prototyping/meta/">Prototyping Collection Meta</a></li>
     <li><a href="/ux-design/meta/">UX Collection Meta</a></li>


### PR DESCRIPTION
Remove remote work links wherever it makes sense.